### PR TITLE
Function-based discovery API alternative

### DIFF
--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -62,11 +62,8 @@ export default class CoapClient implements ProtocolClient {
         req.setOption("Accept", "application/td+json");
         return new Promise<Content>((resolve, reject) => {
             req.on("response", (res: IncomingMessage) => {
-                let contentType = res.headers["Content-Format"];
-                if (typeof contentType !== "string") {
-                    contentType = "application/td+json";
-                }
-                resolve({ type: contentType, body: Readable.from(res.payload) });
+                const contentType = (res.headers["Content-Format"] as string) ?? "application/td+json";
+                resolve(new Content(contentType, Readable.from(res.payload)));
             });
             req.on("error", (err: Error) => reject(err));
             req.end();

--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -38,6 +38,7 @@ import {
     OutgoingMessage,
     ObserveReadStream,
 } from "coap";
+import { ThingDescription } from "wot-thing-description-types";
 
 const { debug, warn } = createLoggers("binding-coap", "coap-client");
 
@@ -53,6 +54,10 @@ export default class CoapClient implements ProtocolClient {
 
         // WoT-specific content formats
         registerFormat(ContentSerdes.JSON_LD, 2100);
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 
     public toString(): string {

--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -57,7 +57,7 @@ export default class CoapClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 
     public toString(): string {

--- a/packages/binding-coap/src/coaps-client.ts
+++ b/packages/binding-coap/src/coaps-client.ts
@@ -25,7 +25,6 @@ import { ProtocolClient, Content, createLoggers, ContentSerdes } from "@node-wot
 import { CoapForm, CoapMethodName, isValidCoapMethod, isSupportedCoapMethod } from "./coap";
 import { CoapClient as coaps, CoapResponse, RequestMethod, SecurityParameters } from "node-coap-client";
 import { Readable } from "stream";
-import { ThingDescription } from "wot-thing-description-types";
 
 const { debug, warn, error } = createLoggers("binding-coap", "coaps-client");
 
@@ -237,7 +236,7 @@ export default class CoapsClient implements ProtocolClient {
         return req;
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-coap/src/coaps-client.ts
+++ b/packages/binding-coap/src/coaps-client.ts
@@ -238,6 +238,6 @@ export default class CoapsClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-coap/src/coaps-client.ts
+++ b/packages/binding-coap/src/coaps-client.ts
@@ -236,7 +236,7 @@ export default class CoapsClient implements ProtocolClient {
         return req;
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-coap/src/coaps-client.ts
+++ b/packages/binding-coap/src/coaps-client.ts
@@ -25,6 +25,7 @@ import { ProtocolClient, Content, createLoggers, ContentSerdes } from "@node-wot
 import { CoapForm, CoapMethodName, isValidCoapMethod, isSupportedCoapMethod } from "./coap";
 import { CoapClient as coaps, CoapResponse, RequestMethod, SecurityParameters } from "node-coap-client";
 import { Readable } from "stream";
+import { ThingDescription } from "wot-thing-description-types";
 
 const { debug, warn, error } = createLoggers("binding-coap", "coaps-client");
 
@@ -234,5 +235,9 @@ export default class CoapsClient implements ProtocolClient {
         );
 
         return req;
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -91,7 +91,7 @@ export default class FileClient implements ProtocolClient {
 
     public setSecurity = (metadata: Array<SecurityScheme>): boolean => false;
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -21,7 +21,6 @@ import { ProtocolClient, Content, createLoggers } from "@node-wot/core";
 import { Subscription } from "rxjs/Subscription";
 import fs = require("fs");
 import path = require("path");
-import { ThingDescription } from "wot-typescript-definitions";
 
 const { debug, warn } = createLoggers("binding-file", "file-client");
 
@@ -92,7 +91,7 @@ export default class FileClient implements ProtocolClient {
 
     public setSecurity = (metadata: Array<SecurityScheme>): boolean => false;
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -93,6 +93,6 @@ export default class FileClient implements ProtocolClient {
     public setSecurity = (metadata: Array<SecurityScheme>): boolean => false;
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -21,6 +21,7 @@ import { ProtocolClient, Content, createLoggers } from "@node-wot/core";
 import { Subscription } from "rxjs/Subscription";
 import fs = require("fs");
 import path = require("path");
+import { ThingDescription } from "wot-typescript-definitions";
 
 const { debug, warn } = createLoggers("binding-file", "file-client");
 
@@ -90,4 +91,8 @@ export default class FileClient implements ProtocolClient {
     }
 
     public setSecurity = (metadata: Array<SecurityScheme>): boolean => false;
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
+    }
 }

--- a/packages/binding-http/src/http-client-impl.ts
+++ b/packages/binding-http/src/http-client-impl.ts
@@ -418,6 +418,6 @@ export default class HttpClient implements ProtocolClient {
         const response = await fetch(uri, { headers });
         // TODO: Result should be validated
         const body = ProtocolHelpers.toNodeStream(response.body as Readable);
-        return { type: response.headers.get("content-type"), body };
+        return new Content(response.headers.get("content-type") ?? "application/td+json", body);
     }
 }

--- a/packages/binding-http/src/http-client-impl.ts
+++ b/packages/binding-http/src/http-client-impl.ts
@@ -410,13 +410,14 @@ export default class HttpClient implements ProtocolClient {
         return url;
     }
 
-    async discoverDirectly(uri: string): Promise<ThingDescription> {
+    async discoverDirectly(uri: string): Promise<Content> {
         // Note: This is still work in progress
         const headers: HeadersInit = {
             Accept: "application/td+json",
         };
         const response = await fetch(uri, { headers });
         // TODO: Result should be validated
-        return await response.json();
+        const body = ProtocolHelpers.toNodeStream(response.body as Readable);
+        return { type: response.headers.get("content-type"), body };
     }
 }

--- a/packages/binding-http/src/http-client-impl.ts
+++ b/packages/binding-http/src/http-client-impl.ts
@@ -409,4 +409,14 @@ export default class HttpClient implements ProtocolClient {
 
         return url;
     }
+
+    async discoverDirectly(uri: string): Promise<ThingDescription> {
+        // Note: This is still work in progress
+        const headers: HeadersInit = {
+            Accept: "application/td+json",
+        };
+        const response = await fetch(uri, { headers });
+        // TODO: Result should be validated
+        return await response.json();
+    }
 }

--- a/packages/binding-mbus/src/mbus-client.ts
+++ b/packages/binding-mbus/src/mbus-client.ts
@@ -147,6 +147,6 @@ export default class MBusClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-mbus/src/mbus-client.ts
+++ b/packages/binding-mbus/src/mbus-client.ts
@@ -145,7 +145,7 @@ export default class MBusClient implements ProtocolClient {
         return result;
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-mbus/src/mbus-client.ts
+++ b/packages/binding-mbus/src/mbus-client.ts
@@ -23,7 +23,6 @@ import { SecurityScheme } from "@node-wot/td-tools";
 import { MBusConnection, PropertyOperation } from "./mbus-connection";
 
 import { Subscription } from "rxjs/Subscription";
-import { ThingDescription } from "wot-typescript-definitions";
 
 const debug = createDebugLogger("binding-mbus", "mbus-client");
 
@@ -146,7 +145,7 @@ export default class MBusClient implements ProtocolClient {
         return result;
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-mbus/src/mbus-client.ts
+++ b/packages/binding-mbus/src/mbus-client.ts
@@ -23,6 +23,7 @@ import { SecurityScheme } from "@node-wot/td-tools";
 import { MBusConnection, PropertyOperation } from "./mbus-connection";
 
 import { Subscription } from "rxjs/Subscription";
+import { ThingDescription } from "wot-typescript-definitions";
 
 const debug = createDebugLogger("binding-mbus", "mbus-client");
 
@@ -143,5 +144,9 @@ export default class MBusClient implements ProtocolClient {
         result["mbus:timeout"] = form["mbus:timeout"] ?? DEFAULT_TIMEOUT;
 
         return result;
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -23,6 +23,7 @@ import { modbusFunctionToEntity } from "./utils";
 import { ModbusConnection, ModbusFormWithDefaults, PropertyOperation } from "./modbus-connection";
 import { Readable } from "stream";
 import { Subscription } from "rxjs/Subscription";
+import { ThingDescription } from "wot-typescript-definitions";
 
 const debug = createDebugLogger("binding-modbus", "modbus-client");
 
@@ -308,5 +309,9 @@ export default class ModbusClient implements ProtocolClient {
         result["modbus:timeout"] ??= DEFAULT_TIMEOUT;
 
         return result as ModbusFormWithDefaults;
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -23,7 +23,6 @@ import { modbusFunctionToEntity } from "./utils";
 import { ModbusConnection, ModbusFormWithDefaults, PropertyOperation } from "./modbus-connection";
 import { Readable } from "stream";
 import { Subscription } from "rxjs/Subscription";
-import { ThingDescription } from "wot-typescript-definitions";
 
 const debug = createDebugLogger("binding-modbus", "modbus-client");
 
@@ -311,7 +310,7 @@ export default class ModbusClient implements ProtocolClient {
         return result as ModbusFormWithDefaults;
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -312,6 +312,6 @@ export default class ModbusClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -310,7 +310,7 @@ export default class ModbusClient implements ProtocolClient {
         return result as ModbusFormWithDefaults;
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -25,6 +25,7 @@ import { IPublishPacket, QoS } from "mqtt";
 import * as url from "url";
 import { Subscription } from "rxjs/Subscription";
 import { Readable } from "stream";
+import { ThingDescription } from "wot-typescript-definitions";
 
 const { debug, warn } = createLoggers("binding-mqtt", "mqtt-client");
 
@@ -198,5 +199,9 @@ export default class MqttClient implements ProtocolClient {
             default:
                 return (qos = 0);
         }
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -200,7 +200,7 @@ export default class MqttClient implements ProtocolClient {
         }
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -25,7 +25,6 @@ import { IPublishPacket, QoS } from "mqtt";
 import * as url from "url";
 import { Subscription } from "rxjs/Subscription";
 import { Readable } from "stream";
-import { ThingDescription } from "wot-typescript-definitions";
 
 const { debug, warn } = createLoggers("binding-mqtt", "mqtt-client");
 
@@ -201,7 +200,7 @@ export default class MqttClient implements ProtocolClient {
         }
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -202,6 +202,6 @@ export default class MqttClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-netconf/src/netconf-client.ts
+++ b/packages/binding-netconf/src/netconf-client.ts
@@ -178,6 +178,6 @@ export default class NetconfClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-netconf/src/netconf-client.ts
+++ b/packages/binding-netconf/src/netconf-client.ts
@@ -23,7 +23,6 @@ import * as AsyncNodeNetcon from "./async-node-netconf";
 import Url from "url-parse";
 import { Readable } from "stream";
 import { Subscription } from "rxjs/Subscription";
-import { ThingDescription } from "wot-typescript-definitions";
 
 const { debug, warn } = createLoggers("binding-netconf", "netconf-client");
 
@@ -177,7 +176,7 @@ export default class NetconfClient implements ProtocolClient {
         return true;
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-netconf/src/netconf-client.ts
+++ b/packages/binding-netconf/src/netconf-client.ts
@@ -176,7 +176,7 @@ export default class NetconfClient implements ProtocolClient {
         return true;
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-netconf/src/netconf-client.ts
+++ b/packages/binding-netconf/src/netconf-client.ts
@@ -23,6 +23,7 @@ import * as AsyncNodeNetcon from "./async-node-netconf";
 import Url from "url-parse";
 import { Readable } from "stream";
 import { Subscription } from "rxjs/Subscription";
+import { ThingDescription } from "wot-typescript-definitions";
 
 const { debug, warn } = createLoggers("binding-netconf", "netconf-client");
 
@@ -174,5 +175,9 @@ export default class NetconfClient implements ProtocolClient {
 
         this.credentials = credentials;
         return true;
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -45,7 +45,7 @@ import { makeBrowsePath } from "node-opcua-service-translate-browse-path";
 import { StatusCodes } from "node-opcua-status-code";
 
 import { schemaDataValue } from "./codec";
-import { FormElementProperty, ThingDescription } from "wot-thing-description-types";
+import { FormElementProperty } from "wot-thing-description-types";
 import { opcuaJsonEncodeVariant } from "node-opcua-json";
 import { Argument, BrowseDescription, BrowseResult } from "node-opcua-types";
 import { isGoodish2, ReferenceTypeIds } from "node-opcua";
@@ -621,7 +621,7 @@ export class OPCUAProtocolClient implements ProtocolClient {
         return new Content("application/json", Readable.from(JSON.stringify(body)));
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -622,6 +622,6 @@ export class OPCUAProtocolClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -45,7 +45,7 @@ import { makeBrowsePath } from "node-opcua-service-translate-browse-path";
 import { StatusCodes } from "node-opcua-status-code";
 
 import { schemaDataValue } from "./codec";
-import { FormElementProperty } from "wot-thing-description-types";
+import { FormElementProperty, ThingDescription } from "wot-thing-description-types";
 import { opcuaJsonEncodeVariant } from "node-opcua-json";
 import { Argument, BrowseDescription, BrowseResult } from "node-opcua-types";
 import { isGoodish2, ReferenceTypeIds } from "node-opcua";
@@ -619,5 +619,9 @@ export class OPCUAProtocolClient implements ProtocolClient {
         }
 
         return new Content("application/json", Readable.from(JSON.stringify(body)));
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -621,7 +621,7 @@ export class OPCUAProtocolClient implements ProtocolClient {
         return new Content("application/json", Readable.from(JSON.stringify(body)));
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 }

--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -29,8 +29,8 @@ export default class WebSocketClient implements ProtocolClient {
         // TODO: implement and remove eslint-ignore-useless-constructor
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("Method not implemented."));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 
     public toString(): string {

--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -20,6 +20,7 @@
 import { ProtocolClient, Content, createLoggers } from "@node-wot/core";
 import { Form, SecurityScheme } from "@node-wot/td-tools";
 import { Subscription } from "rxjs/Subscription";
+import { ThingDescription } from "wot-thing-description-types";
 
 const { debug, warn } = createLoggers("binding-websockets", "ws-client");
 
@@ -27,6 +28,10 @@ export default class WebSocketClient implements ProtocolClient {
     // eslint-disable-next-line no-useless-constructor
     constructor() {
         // TODO: implement and remove eslint-ignore-useless-constructor
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        throw new Error("Method not implemented.");
     }
 
     public toString(): string {

--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -20,7 +20,6 @@
 import { ProtocolClient, Content, createLoggers } from "@node-wot/core";
 import { Form, SecurityScheme } from "@node-wot/td-tools";
 import { Subscription } from "rxjs/Subscription";
-import { ThingDescription } from "wot-thing-description-types";
 
 const { debug, warn } = createLoggers("binding-websockets", "ws-client");
 
@@ -30,7 +29,7 @@ export default class WebSocketClient implements ProtocolClient {
         // TODO: implement and remove eslint-ignore-useless-constructor
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("Method not implemented."));
     }
 

--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -31,7 +31,7 @@ export default class WebSocketClient implements ProtocolClient {
     }
 
     discoverDirectly(uri: string): Promise<ThingDescription> {
-        throw new Error("Method not implemented.");
+        return Promise.reject(new Error("Method not implemented."));
     }
 
     public toString(): string {

--- a/packages/core/example/example.js
+++ b/packages/core/example/example.js
@@ -1,17 +1,25 @@
 const { Servient } = require("@node-wot/core");
 const { HttpClientFactory } = require("@node-wot/binding-http");
+const { CoapClientFactory } = require("@node-wot/binding-coap");
 
 // Note: This example is just for testing/demonstration purposes and
 //       will eventually be removed/moved to the examples package.
 async function discover() {
     const servient = new Servient();
     servient.addClientFactory(new HttpClientFactory());
+    servient.addClientFactory(new CoapClientFactory());
     const wot = await servient.start();
-    for await (const td of wot.discover({
-        url: "http://plugfest.thingweb.io:8083/smart-coffee-machine",
-        method: "direct",
-    })) {
-        console.log(td);
+
+    const httpUrl = "http://plugfest.thingweb.io:8083/smart-coffee-machine";
+    const coapUrl = "coap://plugfest.thingweb.io:5683/smart-coffee-machine";
+
+    for (const url of [httpUrl, coapUrl]) {
+        for await (const td of wot.discover({
+            url,
+            method: "direct",
+        })) {
+            console.log(td);
+        }
     }
 }
 

--- a/packages/core/example/example.js
+++ b/packages/core/example/example.js
@@ -2,7 +2,7 @@ const { Servient } = require("@node-wot/core");
 const { HttpClientFactory } = require("@node-wot/binding-http");
 
 // Note: This example is just for testing/demonstration purposes and
-//       will eventually be moved to the examples package.
+//       will eventually be removed/moved to the examples package.
 async function discover() {
     const servient = new Servient();
     servient.addClientFactory(new HttpClientFactory());

--- a/packages/core/example/example.js
+++ b/packages/core/example/example.js
@@ -1,0 +1,11 @@
+const { Servient } = require("@node-wot/core");
+
+async function discover() {
+    const servient = new Servient();
+    const wot = await servient.start();
+    for await(const td of wot.discover({url: "http://plugfest.thingweb.io:8083/smart-coffee-machine", method: "direct"})) {
+        console.log(td);
+    }
+}
+
+discover();

--- a/packages/core/example/example.js
+++ b/packages/core/example/example.js
@@ -1,9 +1,16 @@
 const { Servient } = require("@node-wot/core");
+const { HttpClientFactory } = require("@node-wot/binding-http");
 
+// Note: This example is just for testing/demonstration purposes and
+//       will eventually be moved to the examples package.
 async function discover() {
     const servient = new Servient();
+    servient.addClientFactory(new HttpClientFactory());
     const wot = await servient.start();
-    for await(const td of wot.discover({url: "http://plugfest.thingweb.io:8083/smart-coffee-machine", method: "direct"})) {
+    for await (const td of wot.discover({
+        url: "http://plugfest.thingweb.io:8083/smart-coffee-machine",
+        method: "direct",
+    })) {
         console.log(td);
     }
 }

--- a/packages/core/example/example.js
+++ b/packages/core/example/example.js
@@ -14,11 +14,13 @@ async function discover() {
     const coapUrl = "coap://plugfest.thingweb.io:5683/smart-coffee-machine";
 
     for (const url of [httpUrl, coapUrl]) {
-        for await (const td of wot.discover({
-            url,
-            method: "direct",
-        })) {
-            console.log(td);
+        console.log(await wot.discovery.direct(url));
+    }
+
+    // Alternative approach
+    for (const url of [httpUrl, coapUrl]) {
+        for await (const result of wot.discovery.directIterator(url)) {
+            console.log(result);
         }
     }
 }

--- a/packages/core/src/protocol-interfaces.ts
+++ b/packages/core/src/protocol-interfaces.ts
@@ -20,7 +20,6 @@ import { Subscription } from "rxjs/Subscription";
 import Servient from "./servient";
 import ExposedThing from "./exposed-thing";
 import { Content } from "./content";
-import { ThingDescription } from "wot-typescript-definitions";
 
 export type PropertyContentMap = Map<string, Content>;
 

--- a/packages/core/src/protocol-interfaces.ts
+++ b/packages/core/src/protocol-interfaces.ts
@@ -20,6 +20,7 @@ import { Subscription } from "rxjs/Subscription";
 import Servient from "./servient";
 import ExposedThing from "./exposed-thing";
 import { Content } from "./content";
+import { ThingDescription } from "wot-typescript-definitions";
 
 export type PropertyContentMap = Map<string, Content>;
 
@@ -58,6 +59,8 @@ export interface ProtocolClient {
 
     /** this client is requested to perform an "unlink" on the resource with the given URI */
     unlinkResource(form: TD.Form): Promise<void>;
+
+    discoverDirectly(uri: string): Promise<ThingDescription>;
 
     subscribeResource(
         form: TD.Form,

--- a/packages/core/src/protocol-interfaces.ts
+++ b/packages/core/src/protocol-interfaces.ts
@@ -60,7 +60,7 @@ export interface ProtocolClient {
     /** this client is requested to perform an "unlink" on the resource with the given URI */
     unlinkResource(form: TD.Form): Promise<void>;
 
-    discoverDirectly(uri: string): Promise<ThingDescription>;
+    discoverDirectly(uri: string): Promise<Content>;
 
     subscribeResource(
         form: TD.Form,

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -22,7 +22,6 @@ import Helpers from "./helpers";
 import { ThingDescription } from "wot-thing-description-types";
 import { createLoggers } from "./logger";
 import ContentManager from "./content-serdes";
-import { InteractionOutput } from "./interaction-output";
 import ProtocolHelpers from "./protocol-helpers";
 
 const { debug } = createLoggers("core", "wot-impl");

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -21,6 +21,7 @@ import ConsumedThing from "./consumed-thing";
 import Helpers from "./helpers";
 import { ThingDescription } from "wot-thing-description-types";
 import { createLoggers } from "./logger";
+import contentSerdes from "./content-serdes";
 
 const { debug } = createLoggers("core", "wot-impl");
 
@@ -45,9 +46,11 @@ class ThingDiscoveryImpl implements AsyncIterable<ThingDescription> {
                 // TODO: This needs to refactored
                 const uriScheme = new URL(this.filter.url).protocol.split(":")[0];
                 const client = this.servient.getClientFor(uriScheme);
-                const thingDescription = client.discoverDirectly(this.filter.url);
+                const result = await client.discoverDirectly(this.filter.url);
+                // TODO: Add TD validation
+                const thingDescription = contentSerdes.contentToValue(result as any, {});
                 this.active = false;
-                yield new Promise<ThingDescription>((resolve) => resolve(thingDescription));
+                yield new Promise<ThingDescription>((resolve) => resolve(thingDescription as ThingDescription));
                 break;
             }
             default:

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -23,6 +23,7 @@ import { ThingDescription } from "wot-thing-description-types";
 import { createLoggers } from "./logger";
 
 const { debug } = createLoggers("core", "wot-impl");
+import fetch from "node-fetch";
 
 class ThingDiscoveryImpl implements AsyncIterable<ThingDescription> {
 
@@ -40,7 +41,6 @@ class ThingDiscoveryImpl implements AsyncIterable<ThingDescription> {
                 if (!this.active) {
                     return;
                 }
-
                 const response = await fetch(this.filter.url);
                 const parsedTd = await response.json();
                 yield new Promise<ThingDescription>(resolve => resolve(parsedTd));
@@ -78,8 +78,8 @@ export default class WoTImpl {
     }
 
     /** @inheritDoc */
-     discover(filter?: WoT.ThingFilter): ThingDiscoveryImpl {
-        return new ThingDiscoveryImpl(filter);
+    discover(filter?: WoT.ThingFilter): WoT.ThingDiscovery {
+        return new ThingDiscoveryImpl(filter) as unknown as WoT.ThingDiscovery;
     }
 
     /** @inheritDoc */

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -43,6 +43,7 @@ class ThingDiscoveryImpl implements AsyncIterable<ThingDescription> {
                 }
                 const response = await fetch(this.filter.url);
                 const parsedTd = await response.json();
+                this.active = false;
                 yield new Promise<ThingDescription>(resolve => resolve(parsedTd));
                 break;
             }

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -43,7 +43,11 @@ class ThingDiscovery {
         // FIXME: application/td+json can't be handled at the moment
 
         const value = ContentManager.contentToValue({ type: "application/json", body: data }, {});
-        return new Promise<ThingDescription>((resolve) => resolve(value as ThingDescription));
+        if (value instanceof Object) {
+            return value as ThingDescription;
+        }
+
+        throw Error(`Could not parse Thing Description obtained from ${url}`);
     }
 
     // Alternative approach.

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -44,19 +44,17 @@ class ThingDiscoveryProcess {
 
     #filter: ThingFilter;
 
-
-
     constructor(filter?: ThingFilter) {
         this.#filter = filter ?? {};
-    };
+    }
 
-    stop(): void  {
+    stop(): void {
         this.#done = true;
     }
 
     // TODO: Implement AsyncIterable
     // async iterable<ThingDescription>;
-  };
+}
 
 export default class WoTImpl {
     private srv: Servient;

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -62,15 +62,18 @@ export default class WoTImpl {
         this.srv = srv;
     }
 
+    /** @inheritDoc */
     async discover(filter?: WoT.ThingFilter): Promise<WoT.ThingDiscoveryProcess> {
         // TODO: Implement this function
         return new ThingDiscoveryProcess(filter);
     }
 
+    /** @inheritDoc */
     async *exploreDirectory(url: string, filter?: WoT.ThingFilter): AsyncGenerator<ThingDiscoveryProcess> {
         yield Promise.reject(new Error("Unimplemented"));
     }
 
+    /** @inheritDoc */
     async requestThingDescription(url: string): Promise<ThingDescription> {
         const uriScheme = new URL(url).protocol.split(":")[0];
         const client = this.srv.getClientFor(uriScheme);

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -69,8 +69,8 @@ export default class WoTImpl {
     }
 
     /** @inheritDoc */
-    async *exploreDirectory(url: string, filter?: WoT.ThingFilter): AsyncGenerator<ThingDiscoveryProcess> {
-        yield Promise.reject(new Error("Unimplemented"));
+    async exploreDirectory(url: string, filter?: WoT.ThingFilter): Promise<WoT.ThingDiscoveryProcess> {
+        return new ThingDiscoveryProcess(filter);
     }
 
     /** @inheritDoc */

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -54,20 +54,33 @@ class ThingDiscovery {
         const uriScheme = new URL(url).protocol.split(":")[0];
         const client = this.servient.getClientFor(uriScheme);
         const result = await client.discoverDirectly(url);
-        const data = await ProtocolHelpers.readStreamFully(result.body);
 
         // TODO: Add TD validation
         // FIXME: application/td+json can't be handled at the moment
 
-        const value = ContentManager.contentToValue({ type: "application/json", body: data }, {});
+        const value = ContentManager.contentToValue({ type: "application/json", body: await result.toBuffer() }, {});
 
         if (value instanceof Object) {
             yield value as ThingDescription;
         }
     }
 
-    async *directory(url: string, filter?: WoT.ThingFilter): AsyncGenerator<ThingDescription> {
-        // Not implemented, do nothing
+    async *exploreDirectory(url: string, filter?: WoT.ThingFilter): AsyncGenerator<ThingDescription> {
+        yield Promise.reject(new Error("Unimplemented"));
+    }
+
+    async requestThingDescription(url: string): Promise<ThingDescription> {
+        const uriScheme = new URL(url).protocol.split(":")[0];
+        const client = this.servient.getClientFor(uriScheme);
+        const result = await client.discoverDirectly(url);
+
+        const value = ContentManager.contentToValue({ type: result.type, body: await result.toBuffer() }, {});
+
+        if (value instanceof Object) {
+            return value as ThingDescription;
+        }
+
+        throw new Error("Not found.");
     }
 }
 

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -27,7 +27,6 @@ import ProtocolHelpers from "./protocol-helpers";
 const { debug } = createLoggers("core", "wot-impl");
 
 class ThingDiscovery {
-
     private servient: Servient;
     constructor(servient: Servient) {
         this.servient = servient;

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -170,8 +170,8 @@ class TDClient implements ProtocolClient {
         return "TDClient";
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("discoverDirectly not implemented"));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("discoverDirectly not implemented.");
     }
 }
 
@@ -244,8 +244,8 @@ class TrapClient implements ProtocolClient {
 
     public setSecurity = (metadata: SecurityScheme[]) => false;
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("discoverDirectly not implemented"));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("discoverDirectly not implemented.");
     }
 }
 
@@ -315,8 +315,8 @@ class TestProtocolClient implements ProtocolClient {
         return true;
     }
 
-    discoverDirectly(uri: string): Promise<Content> {
-        return Promise.reject(new Error("discoverDirectly not implemented"));
+    async discoverDirectly(uri: string): Promise<Content> {
+        throw new Error("discoverDirectly not implemented.");
     }
 }
 

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -170,7 +170,7 @@ class TDClient implements ProtocolClient {
         return "TDClient";
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("discoverDirectly not implemented"));
     }
 }
@@ -244,7 +244,7 @@ class TrapClient implements ProtocolClient {
 
     public setSecurity = (metadata: SecurityScheme[]) => false;
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("discoverDirectly not implemented"));
     }
 }
@@ -315,7 +315,7 @@ class TestProtocolClient implements ProtocolClient {
         return true;
     }
 
-    discoverDirectly(uri: string): Promise<ThingDescription> {
+    discoverDirectly(uri: string): Promise<Content> {
         return Promise.reject(new Error("discoverDirectly not implemented"));
     }
 }

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -169,6 +169,10 @@ class TDClient implements ProtocolClient {
     public toString(): string {
         return "TDClient";
     }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        return Promise.reject(new Error("discoverDirectly not implemented"));
+    }
 }
 
 class TDClientFactory implements ProtocolClientFactory {
@@ -239,6 +243,10 @@ class TrapClient implements ProtocolClient {
     }
 
     public setSecurity = (metadata: SecurityScheme[]) => false;
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        return Promise.reject(new Error("discoverDirectly not implemented"));
+    }
 }
 
 class TrapClientFactory implements ProtocolClientFactory {
@@ -305,6 +313,10 @@ class TestProtocolClient implements ProtocolClient {
     setSecurity(securitySchemes: SecurityScheme[], credentials?: Record<string, unknown>): boolean {
         this.securitySchemes = securitySchemes;
         return true;
+    }
+
+    discoverDirectly(uri: string): Promise<ThingDescription> {
+        return Promise.reject(new Error("discoverDirectly not implemented"));
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "es2018",
         "lib": ["dom"],
         "skipLibCheck": false,
         "module": "commonjs",


### PR DESCRIPTION
After today's discussion in the WoT Scripting API call, I decided to provide an alternative PR to #773 that uses a more "functional" approach to discovery (as proposed by @relu91 in https://github.com/w3c/wot-scripting-api/issues/222), modelling each discovery method as its own method of an internal `ThingDiscovery` object.

Since there was some discussion regarding the return type of the `direct` method, I provided two alternatives, one of which returns a `ThingDescription` object while the other one returns an iterable `AsyncGenerator` (which is a slightly different concept to an `AsyncIterator`, more similar to Dart Streams with a more intuitive API in my opinion).

As I mentioned in the call, a generator/iterator-based return type would also make it possible to support discovery from a multicast URL with the `direct` method, simple yielding multiple TDs if the underlying platform should receive multiple responses. However, this might only be relevant for CoAP over UDP, so this might not be the strongest argument for a generator-based return type. Still, I think it might be worth considering.

In general, I think this looks promising, and I am looking forward to your feedback :)

Edit: Thinking about it, the `AsyncGenerator` should rather still be an `AsyncIterator` in order to be able to cancel the discovery process. 