### PR TITLE
chore(ci): fix syntax error in workflow file, remove Node 20 for now

### DIFF
--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest, windows-latest]
-                node-version: [16.x, 18.x, 20.x]
+                node-version: [16.x, 18.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node-version: [16.x, 18.x, 20.x]
+                node-version: [16.x, 18.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node-version: 16.x, 18.x, 20.x]
+                node-version: [16.x, 18.x, 20.x]
 
         steps:
             - name: Checkout


### PR DESCRIPTION
#974 introduced a small syntax error that caused the workflow not to run anymore. This PR provides a simple fix.