### PR TITLE
fix(examples/counter): correctly display images

### DIFF
--- a/examples/browser/counter.js
+++ b/examples/browser/counter.js
@@ -48,7 +48,18 @@ function showInteractions(thing) {
                 thing
                     .readProperty(property)
                     .then(async (res) => {
-                        ddItem.textContent = await res.value();
+                        switch (res.form?.contentType) {
+                            case "image/svg+xml":
+                                ddItem.innerHTML = await res.value();
+                                break;
+                            case "image/png;base64":
+                                const img = (await res.arrayBuffer()).toString("base64");
+                                ddItem.innerHTML = `<img src="data:image/png;base64,${img}">`;
+                                break;
+                            default:
+                                ddItem.textContent = await res.value();
+                                break;
+                        }
                     })
                     .catch((err) => window.alert("error: " + err));
             };

--- a/examples/scripts/counter.js
+++ b/examples/scripts/counter.js
@@ -109,7 +109,7 @@ WoT.produce({
             readOnly: true,
             forms: [
                 {
-                    contentType: "image/png",
+                    contentType: "image/png;base64",
                 },
             ],
         },

--- a/packages/examples/src/scripts/counter.ts
+++ b/packages/examples/src/scripts/counter.ts
@@ -111,7 +111,7 @@ WoT.produce({
             readOnly: true,
             forms: [
                 {
-                    contentType: "image/png",
+                    contentType: "image/png;base64",
                 },
             ],
         },


### PR DESCRIPTION
I noticed that the current web counter-example does not display the images "correctly". I'm not sure if this was something by design or not, but I think it would be better to not display images as simple text like the following:
![image](https://github.com/eclipse-thingweb/node-wot/assets/3170227/f5caa607-b477-4e50-964d-53b25d4083ff)

With this PR the example looks like this:
![image](https://github.com/eclipse-thingweb/node-wot/assets/3170227/6fe0f814-af68-4f30-b0f8-f01ffc475499)

