### PR TITLE
fix: align "ts-node" and "typescript" version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,21 +59,21 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-            "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-            "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+            "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.18.6",
+                "@babel/helper-validator-identifier": "^7.22.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -168,16 +168,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -325,13 +315,13 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.18",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
         "node_modules/@leichtgewicht/ip-codec": {
@@ -352,12 +342,6 @@
             "engines": {
                 "node": ">=0.11"
             }
-        },
-        "node_modules/@node-oauth/express-oauth-server/node_modules/bluebird": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "dev": true
         },
         "node_modules/@node-oauth/formats": {
             "version": "1.0.0",
@@ -380,12 +364,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@node-oauth/oauth2-server/node_modules/bluebird": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "dev": true
         },
         "node_modules/@node-wot/binding-coap": {
             "resolved": "packages/binding-coap",
@@ -479,9 +457,9 @@
             }
         },
         "node_modules/@petamoriken/float16": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.0.tgz",
-            "integrity": "sha512-AhVAm6SQ+zgxIiOzwVdUcDmKlu/qU39FiYD2UD6kQQaVenrn0dGZewIghWAENGQsvC+1avLCuT+T2/3Gsp/W3w=="
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.1.tgz",
+            "integrity": "sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg=="
         },
         "node_modules/@serialport/binding-abstract": {
             "version": "9.2.3",
@@ -571,9 +549,9 @@
             "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
         },
         "node_modules/@serialport/bindings/node_modules/node-abi": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
-            "integrity": "sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==",
+            "version": "3.45.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
+            "integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -765,9 +743,9 @@
             "dev": true
         },
         "node_modules/@ster5/global-mutex": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ster5/global-mutex/-/global-mutex-1.2.0.tgz",
-            "integrity": "sha512-UmLDijFT0oif4HNuHkXGEolwQe3Eb5x1WX+1fxEMrO92BojeDycn4gjQnZm8d6nZPizzbWrt6SLQgDU+bFALyw=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@ster5/global-mutex/-/global-mutex-1.3.0.tgz",
+            "integrity": "sha512-YDOLvN/G2bHQj7UGpwHI+f2PwxTKYL93Zzs5M7wCehY0HGUcAceOMQAK/n1xJjCVTbkE9zKHkT5baOEoOio/7A=="
         },
         "node_modules/@testdeck/core": {
             "version": "0.1.2",
@@ -914,9 +892,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.40.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.0.tgz",
-            "integrity": "sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==",
+            "version": "8.40.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.1.tgz",
+            "integrity": "sha512-vRb792M4mF1FBT+eoLecmkpLXwxsBHvWWRGJjzbYANBM6DtiJc6yETyv4rqDA6QNjF1pkj1U7LMA6dGb3VYlHw==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -2243,6 +2221,12 @@
                 "readable-stream": "^3.4.0"
             }
         },
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
+        },
         "node_modules/bn.js": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -2646,9 +2630,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-            "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+            "version": "4.21.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
+            "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
             "dev": true,
             "funding": [
                 {
@@ -2658,13 +2642,17 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001449",
-                "electron-to-chromium": "^1.4.284",
-                "node-releases": "^2.0.8",
-                "update-browserslist-db": "^1.0.10"
+                "caniuse-lite": "^1.0.30001489",
+                "electron-to-chromium": "^1.4.411",
+                "node-releases": "^2.0.12",
+                "update-browserslist-db": "^1.0.11"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2815,9 +2803,9 @@
             }
         },
         "node_modules/c8": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/c8/-/c8-7.13.0.tgz",
-            "integrity": "sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==",
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/c8/-/c8-7.14.0.tgz",
+            "integrity": "sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==",
             "dev": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
@@ -2905,9 +2893,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001489",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
-            "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
+            "version": "1.0.30001502",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+            "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
             "dev": true,
             "funding": [
                 {
@@ -3187,9 +3175,9 @@
             }
         },
         "node_modules/coap/node_modules/bl": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.1.tgz",
-            "integrity": "sha512-zk1P1eAEBHhhB+4NfGxqmuV6NgwECnIoRgsOq2ObdEsmoFVIYzJ/Jjcgaj7JOY/8ekH27bIHSV4Si2T+evqu+Q==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.2.tgz",
+            "integrity": "sha512-/ivXMGCGDI0EB4JI4zCqppp79j03vUgZz/zakw7TworE2NVjIuPxpL1Ti0InSsarKqFG5NLFreCBcCCSjtrTQw==",
             "dependencies": {
                 "buffer": "^6.0.3",
                 "inherits": "^2.0.4",
@@ -3736,9 +3724,9 @@
             }
         },
         "node_modules/des.js": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-            "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+            "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
             "dev": true,
             "dependencies": {
                 "inherits": "^2.0.1",
@@ -3931,9 +3919,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.408",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.408.tgz",
-            "integrity": "sha512-vjeaj0u/UYnzA/CIdGXzzcxRLCqRwREYc9YfaWInjIEr7/XPttZ6ShpyqapchEy0S2r6LpLjDBTnNj7ZxnxJKg==",
+            "version": "1.4.427",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.427.tgz",
+            "integrity": "sha512-HK3r9l+Jm8dYAm1ctXEWIC+hV60zfcjS9UA5BDlYvnI5S7PU/yytjpvSrTNrSSRRkuu3tDyZhdkwIczh+0DWaw==",
             "dev": true
         },
         "node_modules/elliptic": {
@@ -4095,9 +4083,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
-            "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
+            "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
             "dev": true
         },
         "node_modules/es-set-tostringtag": {
@@ -5291,18 +5279,6 @@
                 "yaml": "^2.1.3"
             }
         },
-        "node_modules/find-workspaces/node_modules/type-fest": {
-            "version": "3.11.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.11.1.tgz",
-            "integrity": "sha512-aCuRNRERRVh33lgQaJRlUxZqzfhzwTrsE98Mc3o3VXqmiaQdHacgUtJ0esp+7MvZ92qhtzKPeusaX6vIEcoreA==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -5674,6 +5650,18 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globals/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -9782,16 +9770,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/querystring": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.x"
-            }
-        },
         "node_modules/querystring-es3": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
@@ -10211,9 +10189,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "node_modules/schema-utils": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-            "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.2.0.tgz",
+            "integrity": "sha512-0zTyLGyDJYd/MBxG1AhJkKa6fpEBds4OQO2ut0w7OYG+ZGhGea09lijvzsqegYSik88zc7cUtIlnnO+/BvD6gQ==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
@@ -11075,13 +11053,13 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.17.6",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.6.tgz",
-            "integrity": "sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==",
+            "version": "5.17.7",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.7.tgz",
+            "integrity": "sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/source-map": "^0.3.2",
-                "acorn": "^8.5.0",
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.8.2",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -11124,6 +11102,16 @@
                 "uglify-js": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
@@ -11678,12 +11666,12 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.11.1.tgz",
+            "integrity": "sha512-aCuRNRERRVh33lgQaJRlUxZqzfhzwTrsE98Mc3o3VXqmiaQdHacgUtJ0esp+7MvZ92qhtzKPeusaX6vIEcoreA==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11722,9 +11710,9 @@
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
         },
         "node_modules/typescript": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -11945,13 +11933,13 @@
             "integrity": "sha512-enADBvHfhjrwxFMTVWeIIYz51SZ91uC6o2MR/NQTVljJB6HTZ8eQL3Q7JBj3RxNISA14MOwJaU3vpf5R6dyxHA=="
         },
         "node_modules/url": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.1.tgz",
+            "integrity": "sha512-rWS3H04/+mzzJkv0eZ7vEDGiQbgquI1fGfOad6zKvgYQi1SzMmhl7c/DdRGxhaWrVH6z0qWITo8rpnxK/RfEhA==",
             "dev": true,
             "dependencies": {
-                "punycode": "1.3.2",
-                "querystring": "0.2.0"
+                "punycode": "^1.4.1",
+                "qs": "^6.11.0"
             }
         },
         "node_modules/url-parse": {
@@ -11969,9 +11957,9 @@
             "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
         },
         "node_modules/url/node_modules/punycode": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
             "dev": true
         },
         "node_modules/util": {
@@ -12038,6 +12026,16 @@
             },
             "engines": {
                 "node": ">=10.12.0"
+            }
+        },
+        "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
         "node_modules/vary": {
@@ -12132,9 +12130,9 @@
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "node_modules/webpack": {
-            "version": "5.84.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.84.1.tgz",
-            "integrity": "sha512-ZP4qaZ7vVn/K8WN/p990SGATmrL1qg4heP/MrVneczYtpDGJWlrgZv55vxaV2ul885Kz+25MP2kSXkPe3LZfmg==",
+            "version": "5.86.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.86.0.tgz",
+            "integrity": "sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",

--- a/packages/binding-firestore/package.json
+++ b/packages/binding-firestore/package.json
@@ -40,8 +40,8 @@
         "kill-port": "^1.6.1",
         "mocha": "^9.2.2",
         "sinon": "11.1.1",
-        "ts-node": "10.1.0",
-        "typescript": "4.4.3",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.7.4",
         "typescript-standard": "^0.3.36",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.26"
     },

--- a/packages/td-tools/src/thing-model-helpers.ts
+++ b/packages/td-tools/src/thing-model-helpers.ts
@@ -621,7 +621,7 @@ export class ThingModelHelpers {
         const regex = "{{.*?}}";
         const modelString = JSON.stringify(model);
         // first check if model needs map
-        let keys = modelString.match(new RegExp(regex, "g")) || [];
+        let keys: string[] = modelString.match(new RegExp(regex, "g")) || [];
         keys = keys.map((el) => el.replace("{{", "").replace("}}", ""));
         let isValid = true;
         let errors;


### PR DESCRIPTION
I had to manually tweak package.json in firestore and regenerated package-lock.json.

`npm i ts-node@10.9.1 --workspace=./packages/binding-firestore` or alike did not work and resulted in "no workspace" found. I guess this is the case since the workspace is deactivated...

fixes https://github.com/eclipse-thingweb/node-wot/issues/1016