### PR TITLE
tests/binding-opcua: fix guessing of endpoint to localhost

### DIFF
--- a/packages/binding-opcua/test/client-test.ts
+++ b/packages/binding-opcua/test/client-test.ts
@@ -22,18 +22,15 @@ import { VariableIds, OPCUAServer } from "node-opcua";
 import { OPCUAProtocolClient, OPCUAForm, OPCUAFormInvoke } from "../src/opcua-protocol-client";
 import { OpcuaJSONCodec, schemaDataValue } from "../src/codec";
 import { startServer } from "./fixture/basic-opcua-server";
-
+const endpoint = "opc.tcp://localhost:7890";
 const { debug } = createLoggers("binding-opcua", "opcua-protocol-client");
 
 describe("OPCUA Client", function () {
     this.timeout(60000);
 
     let opcuaServer: OPCUAServer;
-    let endpoint: string;
     before(async () => {
         opcuaServer = await startServer();
-        endpoint = opcuaServer.getEndpointUrl();
-        debug(`endpoint = ${endpoint}`);
     });
     before(() => {
         // ensure codec is loaded


### PR DESCRIPTION
Otherwise, the tests were failing in macos since it tries to connect to `opc.tcp://MACPYJ44WVW33:7890` which does not resolve. Ideally [this](https://github.com/node-opcua/node-opcua/blob/master/packages/node-opcua-server/source/base_server.ts#L433) should be changed at node-opcua.

@erossignon 