### PR TITLE
fix(coap-server): correctly expose additional mediatypes

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -192,8 +192,6 @@ export default class CoapServer implements ProtocolServer {
                 opValues
             );
 
-            ProtocolHelpers.updatePropertyFormWithTemplate(form, property);
-
             property.forms.push(form);
             this.logHrefAssignment(port, href, "Property", propertyName);
         }
@@ -209,7 +207,6 @@ export default class CoapServer implements ProtocolServer {
                 "invokeaction"
             );
 
-            ProtocolHelpers.updateActionFormWithTemplate(form, action);
             action.forms.push(form);
 
             this.logHrefAssignment(port, href, "Action", actionName);
@@ -223,7 +220,6 @@ export default class CoapServer implements ProtocolServer {
                 "unsubscribeevent",
             ]);
 
-            ProtocolHelpers.updateEventFormWithTemplate(form, event);
             event.forms.push(form);
 
             this.logHrefAssignment(port, href, "Event", eventName);


### PR DESCRIPTION
As pointed out by @egekorkan on Discord, the testthing example currently does not expose forms with CBOR `contentType`s when using a CoAP server. Trying to debug the problem, I noticed that this is caused by the helper functions `updatePropertyFormWithTemplate`, `updateActionFormWithTemplate`, and `updateEventFormWithTemplate`.

After reading through their source code, I am not actually sure what these functions are supposed to do, therefore I simply removed their invocation from the CoAP server for the time being which fixed the problem. If they are necessary to integrate into a server implementation, maybe you could help me out with using them correctly instead, though. Thanks :)

