### PR TITLE
chore: create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# Default owners (used as a fallback, last matching pattern takes the most precedence)
+* @danielpeintner @relu91
+
+# CoAP-Binding
+/packages/binding-coap/ @JKRhb
+
+# HTTP-Binding
+/packages/binding-http/ @danielpeintner @relu91
+
+# Mbus-Binding
+# /packages/binding-modbus/
+
+# Modbus-Binding
+/packages/binding-modbus/ @relu91
+
+# MQTT-Binding
+/packages/binding-mqtt/ @sebastiankb # @egekorkan
+
+# NETCONF Binding
+# /packages/binding-netconf/
+
+# OPCUA Binding
+# /packages/binding-opcua/
+
+# WebSockets Binding
+# /packages/binding-websockets/
+
+# Browser Bundle
+/packages/browser-bundle/ @danielpeintner @relu91
+
+# CLI
+/packages/browser-bundle/ @danielpeintner @relu91 @mkovatsc
+
+# Core
+/packages/core/ @danielpeintner @relu91 @JKRhb
+
+# TD Tools
+/packages/td-tools/ @danielpeintner @relu91


### PR DESCRIPTION
I took the freedom of creating an initial version of a `CODEOWNERS` file that corresponds with the assignments from https://github.com/eclipse-thingweb/node-wot/pull/989.

With the file, the respective code owners are automatically requested for a review which can be especially useful when the project should further grow in size. However, only repository members with write-access can be added as code owners, which is why some of the packages are currently commented out instead of listing their maintainers as given in the README files (in this case, the default code owners will be requested for review instead).