### PR TITLE
fix (binding-modbus): Reading Modbus URI design

### DIFF
--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -224,11 +224,13 @@ export default class ModbusClient implements ProtocolClient {
     }
 
     private validateAndFillDefaultForm(form: ModbusForm, contentLength = 0): ModbusForm {
-        const result: ModbusForm = { ...form };
         const mode = contentLength > 0 ? "w" : "r";
 
         // Use form values if provided, otherwise use form values (we are more merciful then the spec for retro-compatibility)
         this.overrideFormFromURLPath(form);
+
+        // take over latest content of form into a new result set
+        const result: ModbusForm = { ...form };
 
         if (!form["modbus:function"] && !form["modbus:entity"]) {
             throw new Error("Malformed form: modbus:function or modbus:entity must be defined");

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -128,10 +128,10 @@ describe("Modbus client test", () => {
         };
 
         // eslint-disable-next-line dot-notation
-        client["validateAndFillDefaultForm"](form);
-        form["modbus:unitID"].should.be.equal(2, "unitID  value not set");
-        form["modbus:address"].should.be.equal(2, "address value not set");
-        form["modbus:quantity"].should.be.equal(5, "quantity value not set");
+        const result = client["validateAndFillDefaultForm"](form);
+        result["modbus:unitID"].should.be.equal(2, "unitID  value not set");
+        result["modbus:address"].should.be.equal(2, "address value not set");
+        result["modbus:quantity"].should.be.equal(5, "quantity value not set");
     });
 
     it("should accept just URL parameters without quantity", () => {
@@ -141,9 +141,9 @@ describe("Modbus client test", () => {
         };
 
         // eslint-disable-next-line dot-notation
-        client["validateAndFillDefaultForm"](form);
-        form["modbus:unitID"].should.be.equal(2, "unitID  value not set");
-        form["modbus:address"].should.be.equal(2, "address value not set");
+        const result = client["validateAndFillDefaultForm"](form);
+        result["modbus:unitID"].should.be.equal(2, "unitID  value not set");
+        result["modbus:address"].should.be.equal(2, "address value not set");
     });
 
     it("should override correctly form values with URL", () => {
@@ -156,10 +156,10 @@ describe("Modbus client test", () => {
         };
 
         // eslint-disable-next-line dot-notation
-        client["overrideFormFromURLPath"](form);
-        form["modbus:unitID"].should.be.equal(2, "unitID value not overridden");
-        form["modbus:address"].should.be.equal(2, "address value not overridden");
-        form["modbus:quantity"].should.be.equal(5, "quantity value not overridden");
+        const result = client["validateAndFillDefaultForm"](form);
+        result["modbus:unitID"].should.be.equal(2, "unitID value not overridden");
+        result["modbus:address"].should.be.equal(2, "address value not overridden");
+        result["modbus:quantity"].should.be.equal(5, "quantity value not overridden");
     });
 
     describe("misc", () => {


### PR DESCRIPTION
small fix: If the href is used to assign the register number, quantity and unitId, this was not processed correctly in the validateAndFillDefaultForm method. The parameters were not taken over into the new result set. 