### PR TITLE
chore(ci): re-enable Node 20

### DIFF
--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest, windows-latest]
-                node-version: [16.x, 18.x]
+                node-version: [16.x, 18.x, 20.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -19,9 +19,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
-            - name: npm 7
-              # npm workspaces requires npm v7 or higher
-              run: npm i -g npm@7 --registry=https://registry.npmjs.org
             - name: Install
               run: npm ci
 
@@ -41,14 +38,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Use Node.js 14
+            - name: Use Node.js 16
               uses: actions/setup-node@v1
               with:
-                  node-version: 14
-
-            - name: npm 7
-              # npm workspaces requires npm v7 or higher
-              run: npm i -g npm@7 --registry=https://registry.npmjs.org
+                  node-version: 16
 
             - name: Install
               run: npm ci
@@ -61,10 +54,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - name: install node v14
+            - name: install node v16
               uses: actions/setup-node@v1
               with:
-                  node-version: 14
+                  node-version: 16
             - name: verify packages version consistency accross sub-modules
               run: npm run check:versions
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node-version: [16.x, 18.x]
+                node-version: [16.x, 18.x, 20.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
-            - name: npm 7
-              # npm workspaces requires npm v7 or higher
-              run: npm i -g npm@7 --registry=https://registry.npmjs.org
             - name: Install
               run: npm ci
 
@@ -41,14 +38,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Use Node.js 14
+            - name: Use Node.js 16
               uses: actions/setup-node@v1
               with:
-                  node-version: 14
-
-            - name: npm 7
-              # npm workspaces requires npm v7 or higher
-              run: npm i -g npm@7 --registry=https://registry.npmjs.org
+                  node-version: 16
 
             - name: Install
               run: npm ci
@@ -61,10 +54,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - name: install node v14
+            - name: install node v16
               uses: actions/setup-node@v1
               with:
-                  node-version: 14
+                  node-version: 16
             - name: verify packages version consistency accross sub-modules
               run: npm run check:versions
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ cs.addCodec(new MyCodec("application/myType"));
 ### To use with Node.js
 
 > **Warning**: We no longer actively support Node.js version 14 and lower.
-> Node.js version 20 is not yet supported (https://github.com/eclipse-thingweb/node-wot/issues/1004)
 
 -   [Node.js](https://nodejs.org/) version 14+
 -   [npm](https://www.npmjs.com/) version 7+

--- a/package-lock.json
+++ b/package-lock.json
@@ -7599,7 +7599,8 @@
         "node_modules/nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "optional": true
         },
         "node_modules/nanobench": {
             "version": "2.1.1",
@@ -7860,17 +7861,34 @@
             }
         },
         "node_modules/node-mbus": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/node-mbus/-/node-mbus-1.2.2.tgz",
-            "integrity": "sha512-Acc2Y04U5DHHQO3Bc05chUy0+vcsy07PeTU68HWV2KG8ckS44RNbXP1lfcPvb9ulwy0178pZpqWjO8f7Zp/WTg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/node-mbus/-/node-mbus-2.1.0.tgz",
+            "integrity": "sha512-2yalJliG3e6r6lcxU5Hk/YeNmtebaPiG2FhT2kVAA56lESr/aUUWAyyZJSuzn8AwRkAEI3o/DCQq7dLC3QiMEw==",
             "hasInstallScript": true,
             "dependencies": {
                 "bindings": "^1.5.0",
-                "nan": "~2.14.2",
-                "xml2js": "^0.4.23"
+                "nan": "^2.17.0",
+                "xml2js": "^0.6.2"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/node-mbus/node_modules/nan": {
+            "version": "2.17.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+            "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+        },
+        "node_modules/node-mbus/node_modules/xml2js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/node-netconf": {
@@ -12785,7 +12803,7 @@
             "dependencies": {
                 "@node-wot/core": "0.8.8",
                 "@node-wot/td-tools": "0.8.8",
-                "node-mbus": "^1.2.2",
+                "node-mbus": "^2.1.0",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.26"
             },
             "devDependencies": {

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -39,7 +39,7 @@
     "dependencies": {
         "@node-wot/core": "0.8.8",
         "@node-wot/td-tools": "0.8.8",
-        "node-mbus": "^1.2.2",
+        "node-mbus": "^2.1.0",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.26"
     },
     "scripts": {


### PR DESCRIPTION
This PR updates the node-mbus dependency, incorporating a fix for Node 20, and re-enables the corresponding CI workflow.

Fixes #1004.