### PR TITLE
Add supports for multiple security schemes in http server

### DIFF
--- a/examples/browser/counter.html
+++ b/examples/browser/counter.html
@@ -44,7 +44,7 @@
                     readonly="readonly"
                     id="td_addr"
                     type="url"
-                    value="http://plugfest.thingweb.io:8083/counter"
+                    value="http://localhost:8080/counter"
                 /><!-- http://localhost:8080/counter -->
             </div>
         </div>

--- a/examples/browser/counter.html
+++ b/examples/browser/counter.html
@@ -44,7 +44,7 @@
                     readonly="readonly"
                     id="td_addr"
                     type="url"
-                    value="http://localhost:8080/counter"
+                    value="http://plugfest.thingweb.io:8083/counter"
                 /><!-- http://localhost:8080/counter -->
             </div>
         </div>

--- a/examples/security/oauth/consumer.js
+++ b/examples/security/oauth/consumer.js
@@ -16,7 +16,7 @@ WoTHelpers.fetch("https://localhost:8080/oauth").then((td) => {
     WoT.consume(td).then(async (thing) => {
         try {
             const resp = await thing.invokeAction("sayOk");
-            const result = resp === null || resp === void 0 ? void 0 : resp.value();
+            const result = await (resp === null || resp === void 0 ? void 0 : resp.value());
             console.log("oAuth token was", result);
         } catch (error) {
             console.log("It seems that I couldn't access the resource");

--- a/examples/security/oauth/wot-server-servient-conf.json
+++ b/examples/security/oauth/wot-server-servient-conf.json
@@ -4,14 +4,16 @@
         "allowSelfSigned": true,
         "serverKey": "../privatekey.pem",
         "serverCert": "../certificate.pem",
-        "security": {
-            "scheme": "oauth2",
-            "method": {
-                "name": "introspection_endpoint",
-                "endpoint": "https://localhost:3000/introspect",
-                "allowSelfSigned": true
+        "security": [
+            {
+                "scheme": "oauth2",
+                "method": {
+                    "name": "introspection_endpoint",
+                    "endpoint": "https://localhost:3000/introspect",
+                    "allowSelfSigned": true
+                }
             }
-        }
+        ]
     },
     "credentials": {
         "urn:dev:wot:oauth:test": {

--- a/packages/binding-http/README.md
+++ b/packages/binding-http/README.md
@@ -132,9 +132,11 @@ let httpConfig = {
     allowSelfSigned: true, // client configuration
     serverKey: "privatekey.pem",
     serverCert: "certificate.pem",
-    security: {
-        scheme: "basic", // (username & password)
-    },
+    security: [
+        {
+            scheme: "basic", // (username & password)
+        },
+    ],
 };
 // add HTTPS binding with configuration
 servient.addServer(new HttpServer(httpConfig));
@@ -182,7 +184,7 @@ The protocol binding can be configured using his constructor or trough servient 
     allowSelfSigned?: boolean;               // Accept self signed certificates
     serverKey?: string;                      // HTTPs server secret key file
     serverCert?: string;                     // HTTPs server certificate file
-    security?: TD.SecurityScheme;            // Security scheme of the server
+    security?: TD.SecurityScheme[];          // A list of possible security schemes to be used by things exposed by this servient.
     baseUri?: string                         // A Base URI to be used in the TD in cases where the client will access a different URL than the actual machine serving the thing.  [See Using BaseUri below]
     middleware?: MiddlewareRequestHandler;   // the MiddlewareRequestHandler function. See [Adding a middleware] section below.
 }
@@ -225,9 +227,9 @@ The http protocol binding supports a set of security protocols that can be enabl
         allowSelfSigned: true,
         serverKey: "privatekey.pem",
         serverCert: "certificate.pem",
-        security: {
+        security: [{
             scheme: "basic" // (username & password)
-        }
+        }]
     }
     credentials: {
         "urn:dev:wot:org:eclipse:thingweb:my-example-secure": {

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -66,7 +66,7 @@ export default class HttpServer implements ProtocolServer {
     private readonly address?: string = undefined;
     private readonly baseUri?: string = undefined;
     private readonly urlRewrite?: Record<string, string> = undefined;
-    private readonly supportedSecurityScheme: string[] = ["nosec"];
+    private readonly supportedSecuritySchemes: string[] = ["nosec"];
     private readonly validOAuthClients: RegExp = /.*/g;
     private readonly server: http.Server | https.Server;
     private readonly middleware: MiddlewareRequestHandler | null = null;
@@ -176,7 +176,7 @@ export default class HttpServer implements ProtocolServer {
         if (config.security) {
             if (config.security.length > 1) {
                 // clear the default
-                this.supportedSecurityScheme = [];
+                this.supportedSecuritySchemes = [];
             }
             for (const securityScheme of config.security) {
                 switch (securityScheme.scheme) {
@@ -195,7 +195,7 @@ export default class HttpServer implements ProtocolServer {
                     default:
                         throw new Error(`HttpServer does not support security scheme '${securityScheme.scheme}`);
                 }
-                this.supportedSecurityScheme.push(securityScheme.scheme);
+                this.supportedSecuritySchemes.push(securityScheme.scheme);
             }
         }
     }
@@ -574,7 +574,7 @@ export default class HttpServer implements ProtocolServer {
                 );
             }
 
-            const isSupported = this.supportedSecurityScheme.find((supportedScheme) => {
+            const isSupported = this.supportedSecuritySchemes.find((supportedScheme) => {
                 const thingScheme = thing.securityDefinitions[secCandidate].scheme;
                 return thingScheme === supportedScheme.toLocaleLowerCase();
             });
@@ -582,7 +582,7 @@ export default class HttpServer implements ProtocolServer {
             if (!isSupported) {
                 throw new Error(
                     "Servient does not support thing security schemes. Current scheme supported: " +
-                        this.supportedSecurityScheme.join(", ")
+                        this.supportedSecuritySchemes.join(", ")
                 );
             }
             // We don't need to do anything else, the user has selected one supported security scheme.
@@ -593,9 +593,9 @@ export default class HttpServer implements ProtocolServer {
         if (!thing.securityDefinitions || Object.keys(thing.securityDefinitions).length === 0) {
             // We are using the first supported security scheme as default
             thing.securityDefinitions = {
-                [this.supportedSecurityScheme[0]]: { scheme: this.supportedSecurityScheme[0] },
+                [this.supportedSecuritySchemes[0]]: { scheme: this.supportedSecuritySchemes[0] },
             };
-            thing.security = [this.supportedSecurityScheme[0]];
+            thing.security = [this.supportedSecuritySchemes[0]];
             return;
         }
 
@@ -608,13 +608,13 @@ export default class HttpServer implements ProtocolServer {
                 // see https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
                 // remove version number for oauth2 schemes
                 scheme = scheme === "oauth2" ? scheme.split("2")[0] : scheme;
-                return this.supportedSecurityScheme.includes(scheme.toLocaleLowerCase());
+                return this.supportedSecuritySchemes.includes(scheme.toLocaleLowerCase());
             });
 
             if (!secCandidate) {
                 throw new Error(
                     "Servient does not support any of thing security schemes. Current scheme supported: " +
-                        this.supportedSecurityScheme.join(",") +
+                        this.supportedSecuritySchemes.join(",") +
                         " thing security schemes: " +
                         Object.values(thing.securityDefinitions)
                             .map((schemeDef) => schemeDef.scheme)

--- a/packages/binding-http/src/http.ts
+++ b/packages/binding-http/src/http.ts
@@ -44,7 +44,7 @@ export interface HttpConfig {
     allowSelfSigned?: boolean;
     serverKey?: string;
     serverCert?: string;
-    security?: TD.SecurityScheme;
+    security?: TD.SecurityScheme[];
     middleware?: MiddlewareRequestHandler;
 }
 

--- a/packages/binding-http/src/routes/action.ts
+++ b/packages/binding-http/src/routes/action.ts
@@ -17,8 +17,8 @@ import { Content, Helpers, ProtocolHelpers, createLoggers } from "@node-wot/core
 import {
     isEmpty,
     respondUnallowedMethod,
-    securitySchemeToHTTPHeader,
-    setCORSForThing,
+    securitySchemeToHttpHeader,
+    setCorsForThing,
     validOrDefaultRequestContentType,
 } from "./common";
 import HttpServer from "../http-server";
@@ -62,7 +62,7 @@ export default async function actionRoute(
         return;
     }
     // TODO: refactor this part to move into a common place
-    setCORSForThing(req, res, thing);
+    setCorsForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -70,7 +70,7 @@ export default async function actionRoute(
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHttpHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/common.ts
+++ b/packages/binding-http/src/routes/common.ts
@@ -80,7 +80,7 @@ export function isEmpty(obj: Record<string, unknown>): boolean {
     return true;
 }
 
-export function securitySchemeToHTTPHeader(scheme: string): string {
+export function securitySchemeToHttpHeader(scheme: string): string {
     const [first, ...rest] = scheme;
     // HTTP Authentication Scheme for OAuth does not contain the version number
     // see https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
@@ -88,7 +88,7 @@ export function securitySchemeToHTTPHeader(scheme: string): string {
     return first.toUpperCase() + rest.join("").toLowerCase();
 }
 
-export function setCORSForThing(req: IncomingMessage, res: ServerResponse, thing: ExposedThing): void {
+export function setCorsForThing(req: IncomingMessage, res: ServerResponse, thing: ExposedThing): void {
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
     // Set CORS headers
     if (securityScheme !== "nosec" && req.headers.origin) {

--- a/packages/binding-http/src/routes/common.ts
+++ b/packages/binding-http/src/routes/common.ts
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
-import { ContentSerdes, Helpers, createLoggers } from "@node-wot/core";
+import { ContentSerdes, ExposedThing, Helpers, createLoggers } from "@node-wot/core";
 import { IncomingMessage, ServerResponse } from "http";
 
 const { debug, warn } = createLoggers("binding-http", "routes", "common");
@@ -78,4 +78,23 @@ export function isEmpty(obj: Record<string, unknown>): boolean {
         if (Object.prototype.hasOwnProperty.call(obj, key)) return false;
     }
     return true;
+}
+
+export function securitySchemeToHTTPHeader(scheme: string): string {
+    const [first, ...rest] = scheme;
+    // HTTP Authentication Scheme for OAuth does not contain the version number
+    // see https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+    if (scheme === "oauth2") return "OAuth";
+    return first.toUpperCase() + rest.join("").toLowerCase();
+}
+
+export function setCORSForThing(req: IncomingMessage, res: ServerResponse, thing: ExposedThing): void {
+    const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
+    // Set CORS headers
+    if (securityScheme !== "nosec" && req.headers.origin) {
+        res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
+        res.setHeader("Access-Control-Allow-Credentials", "true");
+    } else {
+        res.setHeader("Access-Control-Allow-Origin", "*");
+    }
 }

--- a/packages/binding-http/src/routes/event.ts
+++ b/packages/binding-http/src/routes/event.ts
@@ -14,7 +14,7 @@
  ********************************************************************************/
 import { IncomingMessage, ServerResponse } from "http";
 import { Content, Helpers, ProtocolHelpers, createLoggers } from "@node-wot/core";
-import { isEmpty, respondUnallowedMethod } from "./common";
+import { isEmpty, respondUnallowedMethod, securitySchemeToHTTPHeader, setCORSForThing } from "./common";
 import HttpServer from "../http-server";
 
 const { warn, debug } = createLoggers("binding-http", "routes", "event");
@@ -42,12 +42,15 @@ export default async function eventRoute(
         return;
     }
     // TODO: refactor this part to move into a common place
+    setCORSForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
-    if (this.getHttpSecurityScheme() !== "NoSec" && !(await this.checkCredentials(thing, req))) {
+    const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
+
+    if (securityScheme !== "nosec" && !(await this.checkCredentials(thing, req))) {
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${this.getHttpSecurityScheme()} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/event.ts
+++ b/packages/binding-http/src/routes/event.ts
@@ -14,7 +14,7 @@
  ********************************************************************************/
 import { IncomingMessage, ServerResponse } from "http";
 import { Content, Helpers, ProtocolHelpers, createLoggers } from "@node-wot/core";
-import { isEmpty, respondUnallowedMethod, securitySchemeToHTTPHeader, setCORSForThing } from "./common";
+import { isEmpty, respondUnallowedMethod, securitySchemeToHttpHeader, setCorsForThing } from "./common";
 import HttpServer from "../http-server";
 
 const { warn, debug } = createLoggers("binding-http", "routes", "event");
@@ -42,7 +42,7 @@ export default async function eventRoute(
         return;
     }
     // TODO: refactor this part to move into a common place
-    setCORSForThing(req, res, thing);
+    setCorsForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -50,7 +50,7 @@ export default async function eventRoute(
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHttpHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/properties.ts
+++ b/packages/binding-http/src/routes/properties.ts
@@ -14,7 +14,7 @@
  ********************************************************************************/
 import { IncomingMessage, ServerResponse } from "http";
 import { ContentSerdes, Helpers, PropertyContentMap, createLoggers } from "@node-wot/core";
-import { respondUnallowedMethod, securitySchemeToHTTPHeader, setCORSForThing } from "./common";
+import { respondUnallowedMethod, securitySchemeToHttpHeader, setCorsForThing } from "./common";
 import HttpServer from "../http-server";
 
 const { error } = createLoggers("binding-http", "routes", "properties");
@@ -33,7 +33,7 @@ export default async function propertiesRoute(
     }
 
     // TODO: refactor this part to move into a common place
-    setCORSForThing(req, res, thing);
+    setCorsForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -41,7 +41,7 @@ export default async function propertiesRoute(
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHttpHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/property-observe.ts
+++ b/packages/binding-http/src/routes/property-observe.ts
@@ -14,7 +14,7 @@
  ********************************************************************************/
 import { IncomingMessage, ServerResponse } from "http";
 import { Content, Helpers, ProtocolHelpers, createLoggers } from "@node-wot/core";
-import { isEmpty, respondUnallowedMethod, securitySchemeToHTTPHeader, setCORSForThing } from "./common";
+import { isEmpty, respondUnallowedMethod, securitySchemeToHttpHeader, setCorsForThing } from "./common";
 import HttpServer from "../http-server";
 
 const { debug, warn } = createLoggers("binding-http", "routes", "property", "observe");
@@ -51,7 +51,7 @@ export default async function propertyObserveRoute(
     }
 
     // TODO: refactor this part to move into a common place
-    setCORSForThing(req, res, thing);
+    setCorsForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -59,7 +59,7 @@ export default async function propertyObserveRoute(
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHttpHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/property-observe.ts
+++ b/packages/binding-http/src/routes/property-observe.ts
@@ -14,7 +14,7 @@
  ********************************************************************************/
 import { IncomingMessage, ServerResponse } from "http";
 import { Content, Helpers, ProtocolHelpers, createLoggers } from "@node-wot/core";
-import { isEmpty, respondUnallowedMethod } from "./common";
+import { isEmpty, respondUnallowedMethod, securitySchemeToHTTPHeader, setCORSForThing } from "./common";
 import HttpServer from "../http-server";
 
 const { debug, warn } = createLoggers("binding-http", "routes", "property", "observe");
@@ -51,12 +51,15 @@ export default async function propertyObserveRoute(
     }
 
     // TODO: refactor this part to move into a common place
+    setCORSForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
-    if (this.getHttpSecurityScheme() !== "NoSec" && !(await this.checkCredentials(thing, req))) {
+    const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
+
+    if (securityScheme !== "nosec" && !(await this.checkCredentials(thing, req))) {
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${this.getHttpSecurityScheme()} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/property.ts
+++ b/packages/binding-http/src/routes/property.ts
@@ -17,8 +17,8 @@ import { Content, Helpers, ProtocolHelpers, createLoggers } from "@node-wot/core
 import {
     isEmpty,
     respondUnallowedMethod,
-    securitySchemeToHTTPHeader,
-    setCORSForThing,
+    securitySchemeToHttpHeader,
+    setCorsForThing,
     validOrDefaultRequestContentType,
 } from "./common";
 import HttpServer from "../http-server";
@@ -71,7 +71,7 @@ export default async function propertyRoute(
     }
 
     // TODO: refactor this part to move into a common place
-    setCORSForThing(req, res, thing);
+    setCorsForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
     const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
 
@@ -79,7 +79,7 @@ export default async function propertyRoute(
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHttpHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/property.ts
+++ b/packages/binding-http/src/routes/property.ts
@@ -14,7 +14,13 @@
  ********************************************************************************/
 import { IncomingMessage, ServerResponse } from "http";
 import { Content, Helpers, ProtocolHelpers, createLoggers } from "@node-wot/core";
-import { isEmpty, respondUnallowedMethod, validOrDefaultRequestContentType } from "./common";
+import {
+    isEmpty,
+    respondUnallowedMethod,
+    securitySchemeToHTTPHeader,
+    setCORSForThing,
+    validOrDefaultRequestContentType,
+} from "./common";
 import HttpServer from "../http-server";
 
 const { error, warn } = createLoggers("binding-http", "routes", "property");
@@ -65,12 +71,15 @@ export default async function propertyRoute(
     }
 
     // TODO: refactor this part to move into a common place
+    setCORSForThing(req, res, thing);
     let corsPreflightWithCredentials = false;
-    if (this.getHttpSecurityScheme() !== "NoSec" && !(await this.checkCredentials(thing, req))) {
+    const securityScheme = thing.securityDefinitions[Helpers.toStringArray(thing.security)[0]].scheme;
+
+    if (securityScheme !== "nosec" && !(await this.checkCredentials(thing, req))) {
         if (req.method === "OPTIONS" && req.headers.origin) {
             corsPreflightWithCredentials = true;
         } else {
-            res.setHeader("WWW-Authenticate", `${this.getHttpSecurityScheme()} realm="${thing.id}"`);
+            res.setHeader("WWW-Authenticate", `${securitySchemeToHTTPHeader(securityScheme)} realm="${thing.id}"`);
             res.writeHead(401);
             res.end();
             return;

--- a/packages/binding-http/src/routes/thing-description.ts
+++ b/packages/binding-http/src/routes/thing-description.ts
@@ -165,7 +165,7 @@ export default async function thingDescriptionRoute(
         const payload = await content.toBuffer();
 
         negotiateLanguage(td, thing, req);
-
+        res.setHeader("Access-Control-Allow-Origin", "*");
         res.setHeader("Content-Type", contentType);
         res.writeHead(200);
         debug(`Sending HTTP response for TD with Content-Type ${contentType}.`);

--- a/packages/binding-http/src/routes/things.ts
+++ b/packages/binding-http/src/routes/things.ts
@@ -22,6 +22,7 @@ export default function thingsRoute(
     res: ServerResponse,
     _params: unknown
 ): void {
+    res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Content-Type", ContentSerdes.DEFAULT);
     res.writeHead(200);
     const list = [];

--- a/packages/binding-http/test/http-server-oauth-tests.ts
+++ b/packages/binding-http/test/http-server-oauth-tests.ts
@@ -42,7 +42,7 @@ class OAuthServerTests {
             method: method,
         };
         this.server = new HttpServer({
-            security: authConfig,
+            security: [authConfig],
         });
 
         await this.server.start(new MockServient());
@@ -79,7 +79,7 @@ class OAuthServerTests {
 
     @test async "should configure oauth"() {
         /* eslint-disable dot-notation */
-        this.server["httpSecurityScheme"].should.be.equal("OAuth");
+        this.server["supportedSecurityScheme"].should.contain("oauth2");
         expect(this.server["oAuthValidator"]).to.be.instanceOf(EndpointValidator);
         /* eslint-enable dot-notation */
     }

--- a/packages/binding-http/test/http-server-oauth-tests.ts
+++ b/packages/binding-http/test/http-server-oauth-tests.ts
@@ -79,7 +79,7 @@ class OAuthServerTests {
 
     @test async "should configure oauth"() {
         /* eslint-disable dot-notation */
-        this.server["supportedSecurityScheme"].should.contain("oauth2");
+        this.server["supportedSecuritySchemes"].should.contain("oauth2");
         expect(this.server["oAuthValidator"]).to.be.instanceOf(EndpointValidator);
         /* eslint-enable dot-notation */
     }

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -416,7 +416,7 @@ class HttpServerTest {
         await httpServer.start(new Servient());
         expect(httpServer.getPort()).to.eq(port); // port test
         // eslint-disable-next-line dot-notation
-        expect(httpServer["supportedSecurityScheme"][0]).to.eq("nosec");
+        expect(httpServer["supportedSecuritySchemes"][0]).to.eq("nosec");
         await httpServer.stop();
     }
 

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -411,11 +411,12 @@ class HttpServerTest {
 
     // https://github.com/eclipse-thingweb/node-wot/issues/181
     @test async "should start and stop a server with no security"() {
-        const httpServer = new HttpServer({ port, security: { scheme: "nosec" } });
+        const httpServer = new HttpServer({ port, security: [{ scheme: "nosec" }] });
 
         await httpServer.start(new Servient());
         expect(httpServer.getPort()).to.eq(port); // port test
-        expect(httpServer.getHttpSecurityScheme()).to.eq("NoSec"); // HTTP security scheme test (nosec -> NoSec)
+        // eslint-disable-next-line dot-notation
+        expect(httpServer["supportedSecurityScheme"][0]).to.eq("nosec");
         await httpServer.stop();
     }
 
@@ -425,9 +426,11 @@ class HttpServerTest {
             port: port2,
             serverKey: "./test/server.key",
             serverCert: "./test/server.cert",
-            security: {
-                scheme: "bearer",
-            },
+            security: [
+                {
+                    scheme: "bearer",
+                },
+            ],
         });
         await httpServer.start(new Servient());
         const testThing = new ExposedThing(new Servient());
@@ -449,9 +452,11 @@ class HttpServerTest {
             port: port2,
             serverKey: "./test/server.key",
             serverCert: "./test/server.cert",
-            security: {
-                scheme: "bearer",
-            },
+            security: [
+                {
+                    scheme: "bearer",
+                },
+            ],
         });
         await httpServer.start(new Servient());
 

--- a/packages/examples/src/bindings/http/example-server-secure.ts
+++ b/packages/examples/src/bindings/http/example-server-secure.ts
@@ -29,9 +29,11 @@ const httpConfig = {
     allowSelfSigned: true, // client configuration
     serverKey: "privatekey.pem",
     serverCert: "certificate.pem",
-    security: {
-        scheme: "basic", // (username & password)
-    },
+    security: [
+        {
+            scheme: "basic", // (username & password)
+        },
+    ],
 };
 // add HTTPS binding with configuration
 servient.addServer(new HttpServer(httpConfig));

--- a/packages/examples/src/security/oauth/consumer.ts
+++ b/packages/examples/src/security/oauth/consumer.ts
@@ -21,7 +21,7 @@ WoTHelpers.fetch("https://localhost:8080/oauth").then((td) => {
     WoT.consume(td as ThingDescription).then(async (thing) => {
         try {
             const resp = await thing.invokeAction("sayOk");
-            const result = resp?.value();
+            const result = await resp?.value();
             console.log("oAuth token was", result);
         } catch (error) {
             console.log("It seems that I couldn't access the resource");

--- a/packages/examples/src/security/oauth/wot-server-servient-conf.json
+++ b/packages/examples/src/security/oauth/wot-server-servient-conf.json
@@ -4,14 +4,16 @@
         "allowSelfSigned": true,
         "serverKey": "../privatekey.pem",
         "serverCert": "../certificate.pem",
-        "security": {
-            "scheme": "oauth2",
-            "method": {
-                "name": "introspection_endpoint",
-                "endpoint": "https://localhost:3000/introspect",
-                "allowSelfSigned": true
+        "security": [
+            {
+                "scheme": "oauth2",
+                "method": {
+                    "name": "introspection_endpoint",
+                    "endpoint": "https://localhost:3000/introspect",
+                    "allowSelfSigned": true
+                }
             }
-        }
+        ]
     },
     "credentials": {
         "urn:dev:wot:oauth:test": {


### PR DESCRIPTION
This PR improves the exposing process of the `http-server`. In particular, it focuses on the ability to handle multiple security schemes per `http-server` instance. For example, now the `http-server` can be configure to be able to hosts Things without security and Things with basic schemes:
```js
const td1 = { } // automatically filled with nosec scheme
const td2 = {securityDefinitions: { basic: {scheme: "basic"}}, security: "basic" }

await (await WoT.produce(td1)).expose();
await (await WoT.produce(td2)).expose();
// ok 
```

**Note** that this does not mean that now we can use multiple security schemes in the `security` field or the `combo` SecurityScheme`. For multiple security schemas, I think we can avoid implementing that feature, mainly because it is already [deprecated in TD 1.1](https://w3c.github.io/wot-thing-description/#td-security-combo-deprecation). On the other hand, the combo scheme will require some additional work. Moreover, this does not introduce support for form-level security fields. It is quite tricky to achieve and we need first to support form templating in the expose method properly. 

