### PR TITLE
Add static address to quickstart examples

### DIFF
--- a/examples/quickstart/simple-coffee-machine.js
+++ b/examples/quickstart/simple-coffee-machine.js
@@ -24,6 +24,7 @@ servient.addServer(
         port: 8081,
     })
 );
+core_1.Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
 let waterAmount = 100;
 let beansAmount = 100;
 let milkAmount = 100;

--- a/examples/quickstart/smart-clock.js
+++ b/examples/quickstart/smart-clock.js
@@ -19,6 +19,7 @@ const binding_coap_1 = require("@node-wot/binding-coap");
 // create Servient add CoAP binding with port configuration
 const servient = new core_1.Servient();
 servient.addServer(new binding_coap_1.CoapServer(5685));
+core_1.Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
 let minuteCounter = 0;
 let hourCounter = 0;
 async function timeCount(thing) {

--- a/packages/examples/src/quickstart/simple-coffee-machine.ts
+++ b/packages/examples/src/quickstart/simple-coffee-machine.ts
@@ -16,7 +16,7 @@
 // This is an example Thing script which is a simple coffee machine.
 // You can order coffee and see the status of the resources
 
-import { Servient } from "@node-wot/core";
+import { Servient, Helpers } from "@node-wot/core";
 import { HttpServer } from "@node-wot/binding-http";
 
 // create Servient add HTTP binding with port configuration
@@ -26,6 +26,8 @@ servient.addServer(
         port: 8081,
     })
 );
+
+Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
 
 let waterAmount = 100;
 let beansAmount = 100;

--- a/packages/examples/src/quickstart/smart-clock.ts
+++ b/packages/examples/src/quickstart/smart-clock.ts
@@ -15,12 +15,14 @@
 
 // This is an example Thing which is a smart clock that runs 60 times faster than real time, where 1 hour happens in 1 minute.
 
-import { Servient } from "@node-wot/core";
+import { Servient, Helpers } from "@node-wot/core";
 import { CoapServer } from "@node-wot/binding-coap";
 
 // create Servient add CoAP binding with port configuration
 const servient = new Servient();
 servient.addServer(new CoapServer(5685));
+
+Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
 
 let minuteCounter = 0;
 let hourCounter = 0;


### PR DESCRIPTION
[The current deployed Things](http://plugfest.thingweb.io:8081/coffee-machine)http://[plugfest.thingweb.io:8081/coffee-machine](http://plugfest.thingweb.io:8081/coffee-machine) have wrong href due to automatic ip address detection. This fixes it.

With @relu91 we have discussed offline and we should simply move to a dockerized setup to manage all Things and their environment variables (like IP address, port etc.). 