### PR TITLE
fix(examples/quickstart/smart-clock): change default port

### DIFF
--- a/examples/quickstart/smart-clock.js
+++ b/examples/quickstart/smart-clock.js
@@ -18,7 +18,7 @@ const core_1 = require("@node-wot/core");
 const binding_coap_1 = require("@node-wot/binding-coap");
 // create Servient add CoAP binding with port configuration
 const servient = new core_1.Servient();
-servient.addServer(new binding_coap_1.CoapServer(5685));
+servient.addServer(new binding_coap_1.CoapServer(5686));
 core_1.Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
 let minuteCounter = 0;
 let hourCounter = 0;

--- a/packages/examples/src/quickstart/smart-clock.ts
+++ b/packages/examples/src/quickstart/smart-clock.ts
@@ -20,7 +20,7 @@ import { CoapServer } from "@node-wot/binding-coap";
 
 // create Servient add CoAP binding with port configuration
 const servient = new Servient();
-servient.addServer(new CoapServer(5685));
+servient.addServer(new CoapServer(5686));
 
 Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
 


### PR DESCRIPTION
Change to an open port. 