### PR TITLE
fix(binding-netconf): use optional chaining for non-null-assertion

### DIFF
--- a/packages/binding-netconf/src/async-node-netconf.ts
+++ b/packages/binding-netconf/src/async-node-netconf.ts
@@ -104,10 +104,7 @@ export class Client {
                     reject(err);
                 } else {
                     debug(
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        `New NetConf router opened connection with host ${this.routerParams!.host}, port ${
-                            this.routerParams!.port
-                        }, username ${this.routerParams!.username}`
+                        `New NetConf router opened connection with host ${this.routerParams?.host}, port ${this.routerParams?.port}, username ${this.routerParams?.username}`
                     );
                     this.connected = true;
                     resolve(undefined);


### PR DESCRIPTION
While working on #1078, I noticed that there is a warning emitted by eslint regarding the use of `!` for non-null-assertions. This PR simply replaces the `!`s with `?` (for optional chaining) which should avoid unwanted errors during runtime if one of the parameters should be undefined.