### PR TITLE
feat!(coap-server): adjust constructor to HTTP server

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -33,6 +33,7 @@ import slugify from "slugify";
 import { Readable } from "stream";
 import { MdnsIntroducer } from "./mdns-introducer";
 import { PropertyElement, DataSchema } from "wot-thing-description-types";
+import { CoapServerConfig } from "./coap";
 
 const { debug, warn, info, error } = createLoggers("binding-coap", "coap-server");
 
@@ -76,9 +77,9 @@ export default class CoapServer implements ProtocolServer {
 
     private readonly coreResources = new Map<string, CoreLinkFormatResource>();
 
-    constructor(port?: number, address?: string) {
-        this.port = port ?? 5683;
-        this.address = address;
+    constructor(config?: CoapServerConfig) {
+        this.port = config?.port ?? 5683;
+        this.address = config?.address;
 
         // WoT-specific content formats
         registerFormat(ContentSerdes.JSON_LD, 2100);

--- a/packages/binding-coap/src/coap.ts
+++ b/packages/binding-coap/src/coap.ts
@@ -27,6 +27,11 @@ export * from "./coap-client";
 export * from "./coaps-client-factory";
 export * from "./coaps-client";
 
+export interface CoapServerConfig {
+    port?: number;
+    address?: string;
+}
+
 export type CoapMethodName = "GET" | "POST" | "PUT" | "DELETE" | "FETCH" | "PATCH" | "iPATCH";
 
 export type BlockSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024;

--- a/packages/binding-coap/test/coap-client-test.ts
+++ b/packages/binding-coap/test/coap-client-test.ts
@@ -55,7 +55,7 @@ class CoapClientTest {
         // testThing.extendInteractions();
         // await testThing.writeProperty("test", "UNSET");
 
-        const coapServer = new CoapServer(port1);
+        const coapServer = new CoapServer({ port: port1 });
 
         await coapServer.start(new Servient());
         expect(coapServer.getPort()).to.equal(port1);
@@ -102,7 +102,7 @@ class CoapClientTest {
     }
 
     @test async "should re-use port"() {
-        const coapServer = new CoapServer(port2, "localhost");
+        const coapServer = new CoapServer({ port: port2, address: "localhost" });
         await coapServer.start(new Servient());
         const coapClient = new CoapClient(coapServer);
         await coapClient.readResource({
@@ -113,7 +113,7 @@ class CoapClientTest {
     }
 
     @test(timeout(5000)) async "subscribe test"() {
-        const coapServer = new CoapServer(port2, "localhost");
+        const coapServer = new CoapServer({ port: port2, address: "localhost" });
         await coapServer.start(new Servient());
         const coapClient = new CoapClient(coapServer);
         const form: CoapForm = {

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -34,7 +34,7 @@ const PORT = 31831;
 @suite("CoAP server implementation")
 class CoapServerTest {
     @test async "should start and stop a server"() {
-        const coapServer = new CoapServer(PORT);
+        const coapServer = new CoapServer({ port: PORT });
 
         await coapServer.start(new Servient());
         expect(coapServer.getPort()).to.eq(PORT); // from test
@@ -44,7 +44,7 @@ class CoapServerTest {
     }
 
     @test async "should read property"() {
-        const coapServer = new CoapServer(PORT);
+        const coapServer = new CoapServer({ port: PORT });
 
         await coapServer.start(new Servient());
 
@@ -75,7 +75,7 @@ class CoapServerTest {
     }
 
     @test async "should write property"() {
-        const coapServer = new CoapServer(PORT);
+        const coapServer = new CoapServer({ port: PORT });
 
         await coapServer.start(new Servient());
 
@@ -114,7 +114,7 @@ class CoapServerTest {
     }
 
     @test async "should perform an action"() {
-        const coapServer = new CoapServer(PORT);
+        const coapServer = new CoapServer({ port: PORT });
 
         await coapServer.start(new Servient());
 
@@ -151,7 +151,7 @@ class CoapServerTest {
     }
 
     @test async "should subscribe to event"() {
-        const coapServer = new CoapServer(PORT);
+        const coapServer = new CoapServer({ port: PORT });
 
         await coapServer.start(new Servient());
 
@@ -185,25 +185,25 @@ class CoapServerTest {
     }
 
     @test async "should cause EADDRINUSE error when already running"() {
-        const portNumber = 9000;
-        const coapServer1 = new CoapServer(portNumber);
+        const port = 9000;
+        const coapServer1 = new CoapServer({ port });
         await coapServer1.start(new Servient());
 
-        expect(coapServer1.getPort()).to.eq(portNumber);
+        expect(coapServer1.getPort()).to.eq(port);
 
-        const coapServer2 = new CoapServer(coapServer1.getPort());
+        const coapServer2 = new CoapServer({ port: coapServer1.getPort() });
 
         try {
             await coapServer2.start(new Servient());
         } catch (err) {
-            expect((err as Error).message).to.eql(`bind EADDRINUSE 0.0.0.0:${portNumber}`);
+            expect((err as Error).message).to.eql(`bind EADDRINUSE 0.0.0.0:${port}`);
         }
 
         await coapServer1.stop();
     }
 
     @test async "should support IPv6"() {
-        const coapServer = new CoapServer(PORT, "::");
+        const coapServer = new CoapServer({ port: PORT, address: "::" });
         await coapServer.start(new Servient());
 
         const testThing = new ExposedThing(new Servient(), {
@@ -232,8 +232,8 @@ class CoapServerTest {
     }
 
     @test async "should take in account global uriVariables"() {
-        const portNumber = 9001;
-        const coapServer = new CoapServer(portNumber);
+        const port = 9001;
+        const coapServer = new CoapServer({ port });
 
         await coapServer.start(new Servient());
 
@@ -284,8 +284,8 @@ class CoapServerTest {
     }
 
     @test async "should support /.well-known/core"() {
-        const portNumber = 9001;
-        const coapServer = new CoapServer(portNumber);
+        const port = 9001;
+        const coapServer = new CoapServer({ port });
 
         await coapServer.start(new Servient());
 
@@ -311,8 +311,8 @@ class CoapServerTest {
     }
 
     @test async "should support TD Content-Format negotiation"() {
-        const portNumber = 5683;
-        const coapServer = new CoapServer(portNumber);
+        const port = 5683;
+        const coapServer = new CoapServer({ port });
 
         await coapServer.start(new Servient());
 
@@ -365,8 +365,8 @@ class CoapServerTest {
     }
 
     @test async "should supply Size2 option when fetching a TD"() {
-        const portNumber = 9002;
-        const coapServer = new CoapServer(portNumber);
+        const port = 9002;
+        const coapServer = new CoapServer({ port });
 
         await coapServer.start(new Servient());
 
@@ -391,11 +391,11 @@ class CoapServerTest {
     }
 
     @test async "should check uriVariables consistency"() {
-        const portNumber = 9003;
-        const coapServer = new CoapServer(portNumber);
+        const port = 9003;
+        const coapServer = new CoapServer({ port });
         const servient = new Servient();
 
-        const baseUri = `coap://localhost:${portNumber}/test`;
+        const baseUri = `coap://localhost:${port}/test`;
 
         await coapServer.start(servient);
 

--- a/packages/cli/src/cli-default-servient.ts
+++ b/packages/cli/src/cli-default-servient.ts
@@ -70,7 +70,7 @@ export default class DefaultServient extends Servient {
         },
         http: {
             port: 8080,
-            selfSigned: false,
+            allowSelfSigned: false,
         },
         coap: {
             port: 5683,
@@ -131,11 +131,9 @@ export default class DefaultServient extends Servient {
                 // re-use httpServer (same port)
                 // this.addServer(new WebSocketServer(httpServer));
             }
-            if (this.config.coap) {
-                coapServer =
-                    typeof this.config.coap.port === "number"
-                        ? new CoapServer(this.config.coap.port)
-                        : new CoapServer();
+            const coapConfig = this.config.coap;
+            if (coapConfig != null) {
+                coapServer = new CoapServer(coapConfig);
                 this.addServer(coapServer);
             }
             if (this.config.mqtt) {

--- a/packages/examples/src/quickstart/smart-clock.ts
+++ b/packages/examples/src/quickstart/smart-clock.ts
@@ -20,7 +20,7 @@ import { CoapServer } from "@node-wot/binding-coap";
 
 // create Servient add CoAP binding with port configuration
 const servient = new Servient();
-servient.addServer(new CoapServer(5686));
+servient.addServer(new CoapServer({ port: 5686 }));
 
 Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
 


### PR DESCRIPTION
As pointed out by @egekorkan in #1028, the CoAP server currently has a different constructor API that differs from its HTTP counterpart.

This PR introduces a `CoapServerConfig` interface that features the previously defined `address` and `port` parameters in order to align it with the HTTP implementation (and probably also other binding implementations). Using this approach will also make it possible to extend the CoAP server more easily in the feature (e.g., with a security configuration).

As this PR introduces a breaking change, however, I suppose merging it should be postponed until the next minor(?) release.

Will resolve #1028.