### PR TITLE
Data Schema Fix for Quickstart example

### DIFF
--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,10 @@
+# Quick Start Things
+
+This set of Things can be used to build mashup applications for a smart home scenario.
+These Things are:
+
+-   Simple coffee machine that can take an order to brew a coffee.
+-   Presence sensor that emits an event when a person is detected.
+-   Smart clock that runs 60 times faster than real time, where 1 hour happens in 1 minute.
+
+These Things are hosted on plugfest.thingweb.io but can be also self-hosted.

--- a/examples/quickstart/simple-coffee-machine.js
+++ b/examples/quickstart/simple-coffee-machine.js
@@ -47,17 +47,17 @@ servient.start().then((WoT) => {
                     water: {
                         type: "integer",
                         minimum: 0,
-                        maximum: 100,
+                        maximum: 1000,
                     },
                     beans: {
                         type: "integer",
                         minimum: 0,
-                        maximum: 100,
+                        maximum: 1000,
                     },
                     milk: {
                         type: "integer",
                         minimum: 0,
-                        maximum: 100,
+                        maximum: 1000,
                     },
                 },
             },

--- a/packages/examples/src/quickstart/simple-coffee-machine.ts
+++ b/packages/examples/src/quickstart/simple-coffee-machine.ts
@@ -53,17 +53,17 @@ servient.start().then((WoT) => {
                     water: {
                         type: "integer",
                         minimum: 0,
-                        maximum: 100,
+                        maximum: 1000,
                     },
                     beans: {
                         type: "integer",
                         minimum: 0,
-                        maximum: 100,
+                        maximum: 1000,
                     },
                     milk: {
                         type: "integer",
                         minimum: 0,
-                        maximum: 100,
+                        maximum: 1000,
                     },
                 },
             },


### PR DESCRIPTION
As discovered in W3C TPAC, we should fix the TD Data Schema otherwise error is returned with property read