### PR TITLE
chore(binding-coap): enable strict-boolean-expressions and null checks

### DIFF
--- a/packages/binding-coap/.eslintrc.json
+++ b/packages/binding-coap/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": "../../.eslintrc.js"
+    "extends": "../../.eslintrc.js",
+    "rules": {
+        "@typescript-eslint/strict-boolean-expressions": ["error"]
+    }
 }

--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -117,7 +117,7 @@ export default class CoapClient implements ProtocolClient {
             });
             req.on("error", (err: Error) => reject(err));
             (async () => {
-                if (content && content.body) {
+                if (content != null) {
                     const buffer = await content.toBuffer();
                     req.setOption("Content-Format", content.type);
                     req.write(buffer);
@@ -159,8 +159,7 @@ export default class CoapClient implements ProtocolClient {
                 debug(`CoapClient received Content-Format: ${res.headers["Content-Format"]}`);
 
                 // FIXME does not work with blockwise because of node-coap
-                let contentType = res.headers["Content-Format"];
-                if (!contentType) contentType = form.contentType;
+                const contentType = res.headers["Content-Format"] ?? form.contentType ?? ContentSerdes.DEFAULT;
 
                 res.on("data", (data: Buffer) => {
                     next(new Content(`${contentType}`, Readable.from(res.payload)));
@@ -203,10 +202,10 @@ export default class CoapClient implements ProtocolClient {
 
         const options: CoapRequestParams = {
             agent: this.agent,
-            hostname: requestUri.hostname || "",
-            port: requestUri.port ? parseInt(requestUri.port, 10) : 5683,
-            pathname: requestUri.pathname || "",
-            query: requestUri.query || "",
+            hostname: requestUri.hostname ?? "",
+            port: requestUri.port != null ? parseInt(requestUri.port, 10) : 5683,
+            pathname: requestUri.pathname ?? "",
+            query: requestUri.query ?? "",
             observe: false,
             multicast: false,
             confirmable: true,

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -360,7 +360,7 @@ export default class CoapServer implements ProtocolServer {
         this.sendContentResponse(res, payload, contentType);
     }
 
-    private processAcceptValue(req: IncomingMessage) {
+    private processAcceptValue(req: IncomingMessage): { contentType: string; isSupported: boolean } {
         const accept = req.headers.Accept;
 
         if (typeof accept !== "string") {
@@ -371,7 +371,7 @@ export default class CoapServer implements ProtocolServer {
             };
         }
 
-        const isSupported = ContentSerdes.get().isSupported(accept);
+        const isSupported: boolean = ContentSerdes.get().isSupported(accept);
 
         if (!isSupported) {
             debug(`Request contained an accept option with value ${accept} which is not supported.`);
@@ -550,9 +550,7 @@ export default class CoapServer implements ProtocolServer {
         res.end();
 
         res.on("finish", (err: Error) => {
-            if (err) {
-                error(`CoapServer on port ${this.port} failed on observe with: ${err.message}`);
-            }
+            error(`CoapServer on port ${this.port} failed on observe with: ${err.message}`);
             thing.handleUnobserveProperty(affordanceKey, listener, interactionOptions);
         });
 
@@ -653,7 +651,7 @@ export default class CoapServer implements ProtocolServer {
                 new Content(contentType, Readable.from(req.payload)),
                 interactionOptions
             );
-            if (output) {
+            if (output != null) {
                 this.streamContentResponse(res, output, { end: true });
             } else {
                 this.sendChangedResponse(res);
@@ -791,7 +789,7 @@ export default class CoapServer implements ProtocolServer {
         return contentType ?? ContentSerdes.DEFAULT;
     }
 
-    private checkContentTypeSupportForInput(method: string, contentType: string) {
+    private checkContentTypeSupportForInput(method: string, contentType: string): boolean {
         const methodsWithPayload: string[] = ["PUT", "POST", "FETCH", "iPATCH", "PATCH"];
         const notAMethodWithPayload = !methodsWithPayload.includes(method);
 

--- a/packages/binding-coap/tsconfig.json
+++ b/packages/binding-coap/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "src"
+        "rootDir": "src",
+        "strictNullChecks": true
     },
     "include": ["src/**/*"],
     "references": [{ "path": "../td-tools" }, { "path": "../core" }]


### PR DESCRIPTION
This PR addresses one of the checkmarks in #1046.