### PR TITLE
test(binding-coap): `await` all calls of `coapServer.stop()`

### DIFF
--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -336,29 +336,32 @@ class CoapServerTest {
             null,
         ];
 
-        const promises = contentFormats.map((contentFormat) => new Promise<void>((resolve) => {
-            const req = request(uri);
+        const promises = contentFormats.map(
+            (contentFormat) =>
+                new Promise<void>((resolve) => {
+                    const req = request(uri);
 
-                if (contentFormat != null) {
-                    req.setHeader("Accept", contentFormat);
-                }
-
-                req.on("response", async (res: IncomingMessage) => {
-                    const requestContentFormat = res.headers["Content-Format"];
-
-                    if (contentFormat === unsupportedContentFormat) {
-                        expect(res.code).to.equal("4.06");
-                        expect(res.payload.toString()).to.equal(
-                            `Content-Format ${unsupportedContentFormat} is not supported by this resource.`
-                        );
-                    } else {
-                        expect(requestContentFormat).to.equal(contentFormat ?? defaultContentFormat);
+                    if (contentFormat != null) {
+                        req.setHeader("Accept", contentFormat);
                     }
 
-                    resolve();
-                });
-                req.end();
-        }));
+                    req.on("response", async (res: IncomingMessage) => {
+                        const requestContentFormat = res.headers["Content-Format"];
+
+                        if (contentFormat === unsupportedContentFormat) {
+                            expect(res.code).to.equal("4.06");
+                            expect(res.payload.toString()).to.equal(
+                                `Content-Format ${unsupportedContentFormat} is not supported by this resource.`
+                            );
+                        } else {
+                            expect(requestContentFormat).to.equal(contentFormat ?? defaultContentFormat);
+                        }
+
+                        resolve();
+                    });
+                    req.end();
+                })
+        );
 
         await Promise.all(promises);
 

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -280,7 +280,7 @@ class CoapServerTest {
         const resp = await coapClient.readResource(new TD.Form(uri + "properties/test?id=testId&globalVarTest=test1"));
         expect((await resp.toBuffer()).toString()).to.equal('"testValue"');
 
-        return coapServer.stop();
+        await coapServer.stop();
     }
 
     @test async "should support /.well-known/core"() {
@@ -307,7 +307,7 @@ class CoapServerTest {
             '</test1>;rt="wot.thing";ct="50 432",</test2>;rt="wot.thing";ct="50 432"'
         );
 
-        return coapServer.stop();
+        await coapServer.stop();
     }
 
     @test async "should support TD Content-Format negotiation"() {
@@ -344,7 +344,7 @@ class CoapServerTest {
                 req.setHeader("Accept", contentFormat);
             }
 
-            req.on("response", (res: IncomingMessage) => {
+            req.on("response", async (res: IncomingMessage) => {
                 const requestContentFormat = res.headers["Content-Format"];
 
                 if (contentFormat === unsupportedContentFormat) {
@@ -357,7 +357,7 @@ class CoapServerTest {
                 }
 
                 if (++responseCounter >= contentFormats.length) {
-                    coapServer.stop();
+                    await coapServer.stop();
                 }
             });
             req.end();
@@ -383,9 +383,9 @@ class CoapServerTest {
             port: coapServer.getPort(),
         });
         req.setOption("Size2", 0);
-        req.on("response", (res) => {
+        req.on("response", async (res) => {
             expect(res.headers.Size2).to.equal(JSON.stringify(testThing.getThingDescription()).length);
-            coapServer.stop();
+            await coapServer.stop();
         });
         req.end();
     }

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -323,7 +323,6 @@ class CoapServerTest {
         await coapServer.expose(testThing);
 
         const uri = `coap://localhost:${coapServer.getPort()}/test`;
-        let responseCounter = 0;
 
         registerFormat("application/foobar", 65000);
 
@@ -337,9 +336,8 @@ class CoapServerTest {
             null,
         ];
 
-        await new Promise<void>((resolve) => {
-            for (const contentFormat of contentFormats) {
-                const req = request(uri);
+        const promises = contentFormats.map((contentFormat) => new Promise<void>((resolve) => {
+            const req = request(uri);
 
                 if (contentFormat != null) {
                     req.setHeader("Accept", contentFormat);
@@ -357,13 +355,12 @@ class CoapServerTest {
                         expect(requestContentFormat).to.equal(contentFormat ?? defaultContentFormat);
                     }
 
-                    if (++responseCounter >= contentFormats.length) {
-                        resolve();
-                    }
+                    resolve();
                 });
                 req.end();
-            }
-        });
+        }));
+
+        await Promise.all(promises);
 
         await coapServer.stop();
     }


### PR DESCRIPTION
In the context of #1086 and #1077, I noticed that in the CoAP tests, not all invocations of `coapServer.stop()` are actually explicitly being awaited which might cause the CI to hang if there is an unexpected error.

This PR makes a couple of minor adjustments to improve the cleanup of resources and fix this potential problem (although I am not sure to which extent it is actually a problem to begin).