### PR TITLE
refactor: use `structuredClone` for deep copying

### DIFF
--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -320,7 +320,7 @@ export default class HttpServer implements ProtocolServer {
             for (const inUri in this.urlRewrite) {
                 const toUri = this.urlRewrite[inUri];
                 if (form.href.endsWith(toUri)) {
-                    const form2: TD.Form = JSON.parse(JSON.stringify(form)); // deep copy
+                    const form2 = structuredClone(form);
                     form2.href = form2.href.substring(0, form.href.lastIndexOf(toUri)) + inUri;
                     forms.push(form2);
                     debug(`HttpServer on port ${this.getPort()} assigns urlRewrite '${form2.href}' for '${form.href}'`);

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -371,7 +371,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         this.events = {};
         // Deep clone the Thing Model
         // without functions or methods
-        const clonedModel = JSON.parse(JSON.stringify(thingModel));
+        const clonedModel = structuredClone(thingModel);
         Object.assign(this, clonedModel);
         this.extendInteractions();
     }

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -369,10 +369,9 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
         this.properties = {};
         this.actions = {};
         this.events = {};
-        // Deep clone the Thing Model
-        // without functions or methods
-        const clonedModel = structuredClone(thingModel);
-        Object.assign(this, clonedModel);
+
+        const deepClonedModel = structuredClone(thingModel);
+        Object.assign(this, deepClonedModel);
         this.extendInteractions();
     }
 

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -100,7 +100,7 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
         this.events = {};
         // Deep clone the Thing Model
         // without functions or methods
-        const clonedModel = JSON.parse(JSON.stringify(thingModel));
+        const clonedModel = structuredClone(thingModel);
         Object.assign(this, clonedModel);
 
         // unset "@type":"tm:ThingModel" ?

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -98,10 +98,9 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
         this.properties = {};
         this.actions = {};
         this.events = {};
-        // Deep clone the Thing Model
-        // without functions or methods
-        const clonedModel = structuredClone(thingModel);
-        Object.assign(this, clonedModel);
+
+        const deepClonedModel = structuredClone(thingModel);
+        Object.assign(this, deepClonedModel);
 
         // unset "@type":"tm:ThingModel" ?
         // see https://github.com/eclipse-thingweb/node-wot/issues/426

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -220,7 +220,7 @@ export default class Helpers implements Resolver {
      * Helper function to remove reserved keywords in required property of TD JSON Schema
      */
     static createExposeThingInitSchema(tdSchema: unknown): SomeJSONSchema {
-        const tdSchemaCopy = JSON.parse(JSON.stringify(tdSchema));
+        const tdSchemaCopy = structuredClone(tdSchema) as SomeJSONSchema;
 
         if (tdSchemaCopy.required !== undefined) {
             const reservedKeywords: Array<string> = [


### PR DESCRIPTION
JavaScript nowadays has a built-in function for deep-cloning called `structuredClone` which makes it possible to get rid of the `JSON.parse(JSON.stringify(foo))` construction. I found a few places where the new function can be used, hopefully increasing readability and performance a bit.

Cases where the parse-stringify-approach still needs to be used *could* be revisited in the future to arrive at a slightly cleaner implementation.