### PR TITLE
refactor: remove unnecessary `new Promise` wrappers

### DIFF
--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -127,10 +127,8 @@ class CoapServerTest {
             },
         });
 
-        testThing.setActionHandler("try", (input: WoT.InteractionOutput) => {
-            return new Promise<string>((resolve, reject) => {
-                resolve("TEST");
-            });
+        testThing.setActionHandler("try", async (input: WoT.InteractionOutput) => {
+            return "TEST";
         });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -444,11 +442,9 @@ class CoapServerTest {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         testThing.properties.test.forms = [];
-        testThing.setActionHandler("try", (input: WoT.InteractionOutput, params?: InteractionOptions) => {
-            return new Promise<string>((resolve, reject) => {
-                expect(params?.uriVariables).to.deep.equal({ step: 5 });
-                resolve("TEST");
-            });
+        testThing.setActionHandler("try", async (input: WoT.InteractionOutput, params?: InteractionOptions) => {
+            expect(params?.uriVariables).to.deep.equal({ step: 5 });
+            return "TEST";
         });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -29,66 +29,56 @@ export default class FileClient implements ProtocolClient {
         return "[FileClient]";
     }
 
-    public readResource(form: Form): Promise<Content> {
-        return new Promise<Content>((resolve, reject) => {
-            const filepath = form.href.split("//");
-            const resource = fs.createReadStream(filepath[1]);
-            const extension = path.extname(filepath[1]);
-            debug(`FileClient found '${extension}' extension`);
-            let contentType;
-            if (form.contentType) {
-                contentType = form.contentType;
-            } else {
-                // *guess* contentType based on file extension
-                contentType = "application/octet-stream";
-                switch (extension) {
-                    case ".txt":
-                    case ".log":
-                    case ".ini":
-                    case ".cfg":
-                        contentType = "text/plain";
-                        break;
-                    case ".json":
-                        contentType = "application/json";
-                        break;
-                    case ".jsonld":
-                        contentType = "application/ld+json";
-                        break;
-                    default:
-                        warn(`FileClient cannot determine media type of '${form.href}'`);
-                }
+    public async readResource(form: Form): Promise<Content> {
+        const filepath = form.href.split("//");
+        const resource = fs.createReadStream(filepath[1]);
+        const extension = path.extname(filepath[1]);
+        debug(`FileClient found '${extension}' extension`);
+        let contentType;
+        if (form.contentType) {
+            contentType = form.contentType;
+        } else {
+            // *guess* contentType based on file extension
+            contentType = "application/octet-stream";
+            switch (extension) {
+                case ".txt":
+                case ".log":
+                case ".ini":
+                case ".cfg":
+                    contentType = "text/plain";
+                    break;
+                case ".json":
+                    contentType = "application/json";
+                    break;
+                case ".jsonld":
+                    contentType = "application/ld+json";
+                    break;
+                default:
+                    warn(`FileClient cannot determine media type of '${form.href}'`);
             }
-            resolve(new Content(contentType, resource));
-        });
+        }
+        return new Content(contentType, resource);
     }
 
-    public writeResource(form: Form, content: Content): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            reject(new Error(`FileClient does not implement write`));
-        });
+    public async writeResource(form: Form, content: Content): Promise<void> {
+        throw new Error("FileClient does not implement write");
     }
 
-    public invokeResource(form: Form, content: Content): Promise<Content> {
-        return new Promise<Content>((resolve, reject) => {
-            reject(new Error(`FileClient does not implement invoke`));
-        });
+    public async invokeResource(form: Form, content: Content): Promise<Content> {
+        throw new Error("FileClient does not implement invoke");
     }
 
-    public unlinkResource(form: Form): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            reject(new Error(`FileClient does not implement unlink`));
-        });
+    public async unlinkResource(form: Form): Promise<void> {
+        throw new Error("FileClient does not implement unlink");
     }
 
-    public subscribeResource(
+    public async subscribeResource(
         form: Form,
         next: (value: Content) => void,
         error?: (error: Error) => void,
         complete?: () => void
     ): Promise<Subscription> {
-        return new Promise<Subscription>((resolve, reject) => {
-            reject(new Error(`FileClient does not implement subscribe`));
-        });
+        throw new Error("FileClient does not implement subscribe");
     }
 
     public async start(): Promise<void> {

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -295,24 +295,20 @@ export default class HttpServer implements ProtocolServer {
         }
     }
 
-    public destroy(thingId: string): Promise<boolean> {
+    public async destroy(thingId: string): Promise<boolean> {
         debug(`HttpServer on port ${this.getPort()} destroying thingId '${thingId}'`);
-        return new Promise<boolean>((resolve, reject) => {
-            let removedThing: ExposedThing | undefined;
-            for (const name of Array.from(this.things.keys())) {
-                const expThing = this.things.get(name);
-                if (expThing?.id === thingId) {
-                    this.things.delete(name);
-                    removedThing = expThing;
-                }
+
+        for (const [name, thing] of this.things.entries()) {
+            if (thing.id === thingId) {
+                this.things.delete(name);
+                info(`HttpServer successfully destroyed '${thing.title}'`);
+
+                return true;
             }
-            if (removedThing) {
-                info(`HttpServer successfully destroyed '${removedThing.title}'`);
-            } else {
-                info(`HttpServer failed to destroy thing with thingId '${thingId}'`);
-            }
-            resolve(removedThing !== undefined);
-        });
+        }
+
+        info(`HttpServer failed to destroy thing with thingId '${thingId}'`);
+        return false;
     }
 
     private addUrlRewriteEndpoints(form: TD.Form, forms: Array<TD.Form>): void {

--- a/packages/binding-http/test/http-client-test.ts
+++ b/packages/binding-http/test/http-client-test.ts
@@ -104,16 +104,10 @@ class TestHttpServer implements ProtocolServer {
         }
     }
 
-    public expose(thing: unknown): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            resolve();
-        });
-    }
+    public async expose(thing: unknown): Promise<void> {}
 
-    public destroy(thingId: string): Promise<boolean> {
-        return new Promise<boolean>((resolve, reject) => {
-            resolve(false);
-        });
+    public async destroy(thingId: string): Promise<boolean> {
+        return false;
     }
 
     public setTestVector(vector: TestVector) {

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -24,7 +24,7 @@ import fetch from "node-fetch";
 
 import HttpServer from "../src/http-server";
 import Servient, { Content, createLoggers, ExposedThing, Helpers } from "@node-wot/core";
-import { DataSchemaValue, InteractionInput, InteractionOptions } from "wot-typescript-definitions";
+import { DataSchemaValue, InteractionOptions } from "wot-typescript-definitions";
 import chaiAsPromised from "chai-as-promised";
 import { Readable } from "stream";
 import { MiddlewareRequestHandler } from "../src/http-server-middleware";
@@ -163,10 +163,8 @@ class HttpServerTest {
             test = await value.value();
         });
 
-        testThing.setActionHandler("try", (input: WoT.InteractionOutput) => {
-            return new Promise<string>((resolve, reject) => {
-                resolve("TEST");
-            });
+        testThing.setActionHandler("try", async (input: WoT.InteractionOutput) => {
+            return "TEST";
         });
 
         await httpServer.expose(testThing);
@@ -276,11 +274,9 @@ class HttpServerTest {
             },
         });
         let test: DataSchemaValue;
-        testThing.setPropertyReadHandler("test", (options) => {
+        testThing.setPropertyReadHandler("test", async (options) => {
             expect(options?.uriVariables).to.deep.equal({ id: "testId" });
-            return new Promise<InteractionInput>((resolve, reject) => {
-                resolve(test);
-            });
+            return test;
         });
         testThing.setPropertyWriteHandler("test", async (value, options) => {
             expect(options?.uriVariables).to.deep.equal({ id: "testId" });
@@ -289,11 +285,9 @@ class HttpServerTest {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         testThing.properties.test.forms = [];
-        testThing.setActionHandler("try", (input: WoT.InteractionOutput, params?: InteractionOptions) => {
-            return new Promise<string>((resolve, reject) => {
-                expect(params?.uriVariables).to.deep.equal({ step: 5 });
-                resolve("TEST");
-            });
+        testThing.setActionHandler("try", async (input: WoT.InteractionOutput, params?: InteractionOptions) => {
+            expect(params?.uriVariables).to.deep.equal({ step: 5 });
+            return "TEST";
         });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -339,10 +333,8 @@ class HttpServerTest {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         testThing.properties.test.forms = [];
-        testThing.setActionHandler("try", (input: WoT.InteractionOutput) => {
-            return new Promise<string>((resolve, reject) => {
-                resolve("TEST");
-            });
+        testThing.setActionHandler("try", async (input: WoT.InteractionOutput) => {
+            return "TEST";
         });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -580,11 +572,9 @@ class HttpServerTest {
             },
         });
         let test: DataSchemaValue;
-        testThing.setPropertyReadHandler("test", (options) => {
+        testThing.setPropertyReadHandler("test", async (options) => {
             expect(options?.uriVariables).to.deep.equal({ id: "testId", globalVarTest: "test1" });
-            return new Promise<InteractionInput>((resolve, reject) => {
-                resolve(test);
-            });
+            return test;
         });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/packages/binding-mbus/src/mbus-client.ts
+++ b/packages/binding-mbus/src/mbus-client.ts
@@ -40,33 +40,25 @@ export default class MBusClient implements ProtocolClient {
         return this.performOperation(form) as Promise<Content>;
     }
 
-    writeResource(form: MBusForm, content: Content): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            throw new Error("Method not implemented.");
-        });
+    async writeResource(form: MBusForm, content: Content): Promise<void> {
+        throw new Error("Method not implemented.");
     }
 
-    invokeResource(form: MBusForm, content: Content): Promise<Content> {
-        return new Promise<Content>((resolve, reject) => {
-            throw new Error("Method not implemented.");
-        });
+    async invokeResource(form: MBusForm, content: Content): Promise<Content> {
+        throw new Error("Method not implemented.");
     }
 
-    unlinkResource(form: MBusForm): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            throw new Error("Method not implemented.");
-        });
+    async unlinkResource(form: MBusForm): Promise<void> {
+        throw new Error("Method not implemented.");
     }
 
-    public subscribeResource(
+    public async subscribeResource(
         form: MBusForm,
         next: (value: Content) => void,
         error?: (error: Error) => void,
         complete?: () => void
     ): Promise<Subscription> {
-        return new Promise<Subscription>((resolve, reject) => {
-            throw new Error("Method not implemented.");
-        });
+        throw new Error("Method not implemented.");
     }
 
     async start(): Promise<void> {

--- a/packages/binding-mbus/test/test-servient.ts
+++ b/packages/binding-mbus/test/test-servient.ts
@@ -30,8 +30,6 @@ export default class DefaultServient extends Servient {
      * start
      */
     public start(): Promise<typeof WoT> {
-        return new Promise<typeof WoT>((resolve, reject) => {
-            return super.start();
-        });
+        return super.start();
     }
 }

--- a/packages/binding-modbus/test/test-servient.ts
+++ b/packages/binding-modbus/test/test-servient.ts
@@ -30,8 +30,6 @@ export default class DefaultServient extends Servient {
      * start
      */
     public start(): Promise<typeof WoT> {
-        return new Promise<typeof WoT>((resolve, reject) => {
-            return super.start();
-        });
+        return super.start();
     }
 }

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -155,13 +155,10 @@ export default class MqttClient implements ProtocolClient {
         const requestUri = new url.URL(form.href);
         const topic = requestUri.pathname.slice(1);
 
-        return new Promise<void>((resolve, reject) => {
-            if (this.client && this.client.connected) {
-                this.client.unsubscribe(topic);
-                debug(`MqttClient unsubscribed from topic '${topic}'`);
-            }
-            resolve();
-        });
+        if (this.client != null && this.client.connected) {
+            this.client.unsubscribe(topic);
+            debug(`MqttClient unsubscribed from topic '${topic}'`);
+        }
     }
 
     public async start(): Promise<void> {

--- a/packages/binding-netconf/src/async-node-netconf.ts
+++ b/packages/binding-netconf/src/async-node-netconf.ts
@@ -80,10 +80,6 @@ export class Client {
         if (credentials.privateKey) {
             this.routerParams.pkey = await fsPromises.readFile(credentials.privateKey, { encoding: "utf8" });
         }
-
-        return new Promise((resolve, reject) => {
-            resolve(undefined);
-        });
     }
 
     openRouter(): Promise<void> {

--- a/packages/binding-netconf/src/netconf-client.ts
+++ b/packages/binding-netconf/src/netconf-client.ts
@@ -72,9 +72,7 @@ export default class NetconfClient implements ProtocolClient {
 
         const result = JSON.stringify(await this.client.rpc(xpathQuery, method, NSs, target));
 
-        return new Promise<Content>((resolve, reject) => {
-            resolve(new Content(contentType, Readable.from(Buffer.from(result))));
-        });
+        return new Content(contentType, Readable.from(Buffer.from(result)));
     }
 
     public async writeResource(form: NetconfForm, content: Content): Promise<void> {

--- a/packages/cli/src/cli-default-servient.ts
+++ b/packages/cli/src/cli-default-servient.ts
@@ -306,38 +306,30 @@ export default class DefaultServient extends Servient {
                         .then((thing) => {
                             thing.setActionHandler("setLogLevel", async (level) => {
                                 const ll = await Helpers.parseInteractionOutput(level);
-                                return new Promise((resolve, reject) => {
-                                    if (typeof ll === "number") {
-                                        this.setLogLevel(ll as number);
-                                    } else if (typeof ll === "string") {
-                                        this.setLogLevel(ll as string);
-                                    } else {
-                                        // try to convert it to strings
-                                        this.setLogLevel(ll + "");
-                                    }
-                                    resolve(`Log level set to '${this.logLevel}'`);
-                                });
+                                if (typeof ll === "number") {
+                                    this.setLogLevel(ll as number);
+                                } else if (typeof ll === "string") {
+                                    this.setLogLevel(ll as string);
+                                } else {
+                                    // try to convert it to strings
+                                    this.setLogLevel(ll + "");
+                                }
+                                return `Log level set to '${this.logLevel}'`;
                             });
-                            thing.setActionHandler("shutdown", () => {
-                                return new Promise((resolve, reject) => {
-                                    debug("shutting down by remote");
-                                    this.shutdown();
-                                    resolve(undefined);
-                                });
+                            thing.setActionHandler("shutdown", async () => {
+                                debug("shutting down by remote");
+                                await this.shutdown();
+                                return undefined;
                             });
                             thing.setActionHandler("runScript", async (script) => {
                                 const scriptv = await Helpers.parseInteractionOutput(script);
-                                return new Promise((resolve, reject) => {
-                                    debug("running script", scriptv);
-                                    this.runScript(scriptv as string);
-                                    resolve(undefined);
-                                });
+                                debug("running script", scriptv);
+                                this.runScript(scriptv as string);
+                                return undefined;
                             });
-                            thing.setPropertyReadHandler("things", () => {
-                                return new Promise((resolve, reject) => {
-                                    debug("returnings things");
-                                    resolve(this.getThings());
-                                });
+                            thing.setPropertyReadHandler("things", async () => {
+                                debug("returnings things");
+                                return this.getThings();
                             });
                             thing
                                 .expose()

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -147,15 +147,13 @@ class TDClient implements ProtocolClient {
         return Promise.reject(new Error("unlinkResource not implemented"));
     }
 
-    public subscribeResource(
+    public async subscribeResource(
         form: Form,
         next: (value: Content) => void,
         error?: (error: Error) => void,
         complete?: () => void
     ): Promise<Subscription> {
-        return new Promise<Subscription>((resolve, reject) => {
-            resolve(new Subscription());
-        });
+        return new Subscription();
     }
 
     public async start(): Promise<void> {
@@ -217,21 +215,19 @@ class TrapClient implements ProtocolClient {
         await this.trap(form);
     }
 
-    public subscribeResource(
+    public async subscribeResource(
         form: Form,
         next: (value: Content) => void,
         error?: (error: Error) => void,
         complete?: () => void
     ): Promise<Subscription> {
-        return new Promise<Subscription>((resolve, reject) => {
-            // send one event
-            next(this.trap(form) as Content);
-            // then complete
-            setImmediate(() => {
-                complete?.();
-            });
-            resolve(new Subscription());
+        // send one event
+        next(this.trap(form) as Content);
+        // then complete
+        setImmediate(() => {
+            complete?.();
         });
+        return new Subscription();
     }
 
     public async start(): Promise<void> {
@@ -462,12 +458,9 @@ class WoTClientTest {
         const thing = await WoTClientTest.WoT.consume(td);
         expect(thing).to.have.property("title").that.equals("aThing");
         expect(thing).to.have.property("events").that.has.property("anEvent");
-        return new Promise((resolve) => {
-            thing.subscribeEvent("anEvent", async (x) => {
-                const value = await x.value();
-                expect(value).to.equal("triggered");
-                resolve(true);
-            });
+        await thing.subscribeEvent("anEvent", async (x) => {
+            const value = await x.value();
+            expect(value).to.equal("triggered");
         });
     }
 

--- a/packages/core/test/ServerTest.ts
+++ b/packages/core/test/ServerTest.ts
@@ -43,29 +43,15 @@ chaiUse(spies);
 class TestProtocolServer implements ProtocolServer {
     public readonly scheme: string = "test";
 
-    expose(thing: ExposedThing): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            resolve();
-        });
+    async expose(thing: ExposedThing): Promise<void> {}
+
+    async destroy(thingId: string): Promise<boolean> {
+        return true;
     }
 
-    destroy(thingId: string): Promise<boolean> {
-        return new Promise<boolean>((resolve, reject) => {
-            resolve(true);
-        });
-    }
+    async start(): Promise<void> {}
 
-    start(): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            resolve();
-        });
-    }
-
-    stop(): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            resolve();
-        });
-    }
+    async stop(): Promise<void> {}
 
     getPort(): number {
         return -1;
@@ -279,10 +265,8 @@ class WoTServerTest {
         });
         const number: WoT.DataSchemaValue = 1; // init
 
-        const readHandler = () => {
-            return new Promise<InteractionInput>((resolve) => {
-                resolve(number);
-            });
+        const readHandler = async () => {
+            return number;
         };
 
         thing.setPropertyReadHandler("my number", readHandler);

--- a/packages/examples/src/scripts/smart-coffee-machine.ts
+++ b/packages/examples/src/scripts/smart-coffee-machine.ts
@@ -376,10 +376,8 @@ Assumes one medium americano if not specified, but time and mode are mandatory f
             // Check if the amount of available resources is sufficient to make a drink
             for (const resource in newResources) {
                 if (newResources[resource] <= 0) {
-                    return new Promise((resolve, reject) => {
-                        thing.emitEvent("outOfResource", `Low level of ${resource}: ${newResources[resource]}%`);
-                        return { result: false, message: `${resource} level is not sufficient` };
-                    });
+                    thing.emitEvent("outOfResource", `Low level of ${resource}: ${newResources[resource]}%`);
+                    return { result: false, message: `${resource} level is not sufficient` };
                 }
             }
 
@@ -407,9 +405,8 @@ Assumes one medium americano if not specified, but time and mode are mandatory f
 
                 return { result: true, message: `Your schedule has been set!` };
             }
-            return new Promise((resolve, reject) => {
-                resolve({ result: false, message: `Please provide all the required parameters: time and mode.` });
-            });
+
+            return { result: false, message: `Please provide all the required parameters: time and mode.` };
         });
 
         // Finally expose the thing


### PR DESCRIPTION
This PR contributes to resolving #569. There are a few instances of the `return Promise` pattern left that were a bit difficult to resolve, though, so I am not sure whether we should keep the issue open?