### PR TITLE
chore: enable strictNullChecks globally

### DIFF
--- a/packages/binding-coap/tsconfig.json
+++ b/packages/binding-coap/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "src",
-        "strictNullChecks": true
+        "rootDir": "src"
     },
     "include": ["src/**/*"],
     "references": [{ "path": "../td-tools" }, { "path": "../core" }]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "resolveJsonModule": true,
         "outDir": "dist",
-        "rootDir": "src",
-        "strictNullChecks": true
+        "rootDir": "src"
     },
     "include": ["src/**/*"],
     "references": [{ "path": "../td-tools" }]

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -5,8 +5,7 @@
         "rootDir": "src",
         "target": "ES2018",
         "sourceMap": false,
-        "removeComments": false,
-        "strictNullChecks": true
+        "removeComments": false
     },
     "include": ["src/**/*"],
     "references": [{ "path": "../td-tools" }]

--- a/packages/td-tools/tsconfig.json
+++ b/packages/td-tools/tsconfig.json
@@ -4,8 +4,7 @@
         "resolveJsonModule": true,
         "types": ["node", "readable-stream"],
         "outDir": "dist",
-        "rootDir": "src",
-        "strictNullChecks": true
+        "rootDir": "src"
     },
     "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
         "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
         "resolveJsonModule": false,
         "skipDefaultLibCheck": false,
-        "allowJs": false
+        "allowJs": false,
+        "strictNullChecks": true
     },
     "references": [
         { "path": "./packages/binding-coap" },


### PR DESCRIPTION
As another step towards resolving #1046, this PR enables `strictNullChecks` globally and removes it from individual packages that extend the global `tsconfig.json` file.