### PR TITLE
fix: minor follow-up for PR#1129 AID ranges

### DIFF
--- a/packages/td-tools/src/util/asset-interface-description.ts
+++ b/packages/td-tools/src/util/asset-interface-description.ts
@@ -854,7 +854,8 @@ export class AssetInterfaceDescriptionUtil {
                         if (propertyValue.minimum != null || propertyValue.maximum != null) {
                             const minMax: { [k: string]: unknown } = {
                                 idShort: "min_max",
-                                valueType: "xs:integer",
+                                valueType:
+                                    "integer".localeCompare(propertyValue.type) === 0 ? "xs:integer" : "xs:double",
                                 modelType: "Range",
                             };
                             if (propertyValue.minimum != null) {

--- a/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
+++ b/packages/td-tools/test/AssetInterfaceDescriptionTest.ts
@@ -405,6 +405,8 @@ class AssetInterfaceDescriptionUtilTest {
                                         hasMinMax = true;
                                         expect(propProperty.min).to.equal("0");
                                         expect(propProperty.max).to.equal("100");
+                                        expect(propProperty.valueType).to.equal("xs:integer");
+                                        expect(propProperty.modelType).to.equal("Range");
                                     } else if (propProperty.idShort === "forms") {
                                         hasForms = true;
                                         expect(propProperty)


### PR DESCRIPTION
AID valueType can be "xs:integer" or "xs:double"