### PR TITLE
ci: set a timeout for testing step of ten minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
 
             - name: Test with coverage report
               run: npm run coverage:only
+              timeout-minutes: 10
 
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v2


### PR DESCRIPTION
This might require some discussion/fine-tuning, but since some of our tests are currently hanging for a long time on a regular basis before they are eventually canceled (after reaching the maximum of six hours), this PR proposes limiting the actual testing step to a maximum of five minutes, so that the CI workflow is aborted much earlier than it is now.

I chose five minutes for now because in general, the testing step seems to take about three minutes at maximum, but we could also consider setting it to a higher value – I guess anything lower than `360` would already be an improvement 😅

I think a change like this will also be good for receiving feedback on failed tests much earlier than is currently the case, as any failing test present in a PR might cause this behavior.