### PR TITLE
refactor: revert back to *old* way of cloning

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,14 @@
         },
         {
             "type": "node",
+            "request": "launch",
+            "name": "Launch Counter",
+            "program": "${workspaceRoot}/packages/cli/dist/cli.js",
+            "args": ["counter.js"],
+            "cwd": "${workspaceRoot}/examples/scripts/"
+        },
+        {
+            "type": "node",
             "request": "attach",
             "name": "Attach to Remote",
             "address": "localhost",

--- a/packages/cli/src/cli-default-servient.ts
+++ b/packages/cli/src/cli-default-servient.ts
@@ -123,7 +123,7 @@ export default class DefaultServient extends Servient {
         }
 
         let coapServer: CoapServer | undefined;
-        if (this.config.servient.clientOnly == null) {
+        if (this.config.servient.clientOnly === false) {
             if (this.config.http != null) {
                 const httpServer = new HttpServer(this.config.http);
                 this.addServer(httpServer);

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -122,7 +122,9 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
         this.actions = {};
         this.events = {};
 
-        const deepClonedModel = structuredClone(thingModel);
+        // Deep clone the Thing Model
+        // without functions or methods
+        const deepClonedModel = JSON.parse(JSON.stringify(thingModel));
         Object.assign(this, deepClonedModel);
 
         // unset "@type":"tm:ThingModel" ?


### PR DESCRIPTION
Note: reverts parts of https://github.com/eclipse-thingweb/node-wot/pull/1105

fixes https://github.com/eclipse-thingweb/node-wot/issues/1151