### PR TITLE
chore: increase version numbers to 0.8.11 for next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,18 +94,18 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-            "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+            "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
+            "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -148,21 +148,21 @@
             "dev": true
         },
         "node_modules/@eslint/js": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
+            "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.11",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-            "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+            "version": "0.11.13",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
+                "@humanwhocodes/object-schema": "^2.0.1",
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.5"
             },
@@ -184,9 +184,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
         },
         "node_modules/@istanbuljs/schema": {
@@ -249,9 +249,9 @@
             "dev": true
         },
         "node_modules/@node-oauth/oauth2-server": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@node-oauth/oauth2-server/-/oauth2-server-4.3.2.tgz",
-            "integrity": "sha512-hZDXOWkhZF1edffMf+NERjnRBj839N9YzYkKNZ0/+E2Q2AvvIZOtuvqVkHZYIiYEolv1E3Fr22hUb8nlxiTArQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@node-oauth/oauth2-server/-/oauth2-server-4.3.3.tgz",
+            "integrity": "sha512-0LiQ6sGwgd+WPQCkayORgv3ju6JNcZsU9IpiXSGCQ/LNlvhQCgwriVaVageXl1J9GwY/rq4wMg6DPwakGZLC2g==",
             "dev": true,
             "dependencies": {
                 "@node-oauth/formats": "1.0.0",
@@ -356,15 +356,15 @@
             }
         },
         "node_modules/@peculiar/asn1-cms": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.6.tgz",
-            "integrity": "sha512-Kr0XsyjuElTc4NijuPYyd6YkTlbz0KCuoWnNkfPFhXjHTzbUIh/s15ixjxLj8XDrXsI1aPQp3D64uHbrs3Kuyg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.8.tgz",
+            "integrity": "sha512-Wtk9R7yQxGaIaawHorWKP2OOOm/RZzamOmSWwaqGphIuU6TcKYih0slL6asZlSSZtVoYTrBfrddSOD/jTu9vuQ==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
-                "@peculiar/asn1-x509-attr": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
+                "@peculiar/asn1-x509-attr": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
@@ -373,14 +373,14 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-csr": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.6.tgz",
-            "integrity": "sha512-gCTEB/PvUxapmxo4SzGZT1JtEdevRnphRGZZmc9oJE7+pLuj2Px0Q6x+w8VvObfozA3pyPRTq+Wkocnu64+oLw==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.8.tgz",
+            "integrity": "sha512-ZmAaP2hfzgIGdMLcot8gHTykzoI+X/S53x1xoGbTmratETIaAbSWMiPGvZmXRA0SNEIydpMkzYtq4fQBxN1u1w==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
@@ -389,14 +389,14 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-ecc": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.6.tgz",
-            "integrity": "sha512-Hu1xzMJQWv8/GvzOiinaE6XiD1/kEhq2C/V89UEoWeZ2fLUcGNIvMxOr/pMyL0OmpRWj/mhCTXOZp4PP+a0aTg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.8.tgz",
+            "integrity": "sha512-Ah/Q15y3A/CtxbPibiLM/LKcMbnLTdUdLHUgdpB5f60sSvGkXzxJCu5ezGTFHogZXWNX3KSmYqilCrfdmBc6pQ==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
@@ -405,16 +405,16 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-pfx": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.6.tgz",
-            "integrity": "sha512-bScrrpQ59mppcoZLkDEW/Wruu+daSWQxpR2vqGjg69+v7VoQ1Le/Elm10ObfNShV2eNNridNQcOQvsHMLvUOCg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.8.tgz",
+            "integrity": "sha512-XhdnCVznMmSmgy68B9pVxiZ1XkKoE1BjO4Hv+eUGiY1pM14msLsFZ3N7K46SoITIVZLq92kKkXpGiTfRjlNLyg==",
             "dependencies": {
-                "@peculiar/asn1-cms": "^2.3.6",
-                "@peculiar/asn1-pkcs8": "^2.3.6",
-                "@peculiar/asn1-rsa": "^2.3.6",
-                "@peculiar/asn1-schema": "^2.3.6",
+                "@peculiar/asn1-cms": "^2.3.8",
+                "@peculiar/asn1-pkcs8": "^2.3.8",
+                "@peculiar/asn1-rsa": "^2.3.8",
+                "@peculiar/asn1-schema": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
@@ -423,14 +423,14 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-pkcs8": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.6.tgz",
-            "integrity": "sha512-poqgdjsHNiyR0gnxP8l5VjRInSgpQvOM3zLULF/ZQW67uUsEiuPfplvaNJUlNqNOCd2szGo9jKW9+JmVVpWojA==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.8.tgz",
+            "integrity": "sha512-rL8k2x59v8lZiwLRqdMMmOJ30GHt6yuHISFIuuWivWjAJjnxzZBVzMTQ72sknX5MeTSSvGwPmEFk2/N8+UztFQ==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
@@ -439,18 +439,18 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-pkcs9": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.6.tgz",
-            "integrity": "sha512-uaxSBF60glccuu5BEZvoPsaJzebVYcQRjXx2wXsGe7Grz/BXtq5RQAJ/3i9fEXawFK/zIbvbXBBpy07cnvrqhA==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.8.tgz",
+            "integrity": "sha512-+nONq5tcK7vm3qdY7ZKoSQGQjhJYMJbwJGbXLFOhmqsFIxEWyQPHyV99+wshOjpOjg0wUSSkEEzX2hx5P6EKeQ==",
             "dependencies": {
-                "@peculiar/asn1-cms": "^2.3.6",
-                "@peculiar/asn1-pfx": "^2.3.6",
-                "@peculiar/asn1-pkcs8": "^2.3.6",
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
-                "@peculiar/asn1-x509-attr": "^2.3.6",
+                "@peculiar/asn1-cms": "^2.3.8",
+                "@peculiar/asn1-pfx": "^2.3.8",
+                "@peculiar/asn1-pkcs8": "^2.3.8",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
+                "@peculiar/asn1-x509-attr": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
@@ -459,14 +459,14 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-rsa": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.6.tgz",
-            "integrity": "sha512-DswjJyAXZnvESuImGNTvbNKvh1XApBVqU+r3UmrFFTAI23gv62byl0f5OFKWTNhCf66WQrd3sklpsCZc/4+jwA==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.8.tgz",
+            "integrity": "sha512-ES/RVEHu8VMYXgrg3gjb1m/XG0KJWnV4qyZZ7mAg7rrF3VTmRbLxO8mk+uy0Hme7geSMebp+Wvi2U6RLLEs12Q==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
@@ -475,13 +475,13 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-schema": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-            "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+            "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
             "dependencies": {
                 "asn1js": "^3.0.5",
-                "pvtsutils": "^1.3.2",
-                "tslib": "^2.4.0"
+                "pvtsutils": "^1.3.5",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
@@ -490,40 +490,32 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-x509": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.6.tgz",
-            "integrity": "sha512-dRwX31R1lcbIdzbztiMvLNTDoGptxdV7HocNx87LfKU0fEWh7fTWJjx4oV+glETSy6heF/hJHB2J4RGB3vVSYg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.8.tgz",
+            "integrity": "sha512-voKxGfDU1c6r9mKiN5ZUsZWh3Dy1BABvTM3cimf0tztNwyMJPhiXY94eRTgsMQe6ViLfT6EoXxkWVzcm3mFAFw==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "ipaddr.js": "^2.0.1",
-                "pvtsutils": "^1.3.2",
-                "tslib": "^2.4.0"
+                "ipaddr.js": "^2.1.0",
+                "pvtsutils": "^1.3.5",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-x509-attr": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.6.tgz",
-            "integrity": "sha512-x5Kax8xp3fz+JSc+4Sq0/SUXIdbJeOePibYqvjHMGkP6AoeCOVcP+gg7rZRRGkTlDSyQnAoUTgTEsfAfFEd1/g==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.8.tgz",
+            "integrity": "sha512-4Z8mSN95MOuX04Aku9BUyMdsMKtVQUqWnr627IheiWnwFoheUhX3R4Y2zh23M7m80r4/WG8MOAckRKc77IRv6g==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
                 "asn1js": "^3.0.5",
-                "tslib": "^2.4.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-        "node_modules/@peculiar/asn1-x509/node_modules/ipaddr.js": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
-            "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
-            "engines": {
-                "node": ">= 10"
-            }
         },
         "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
             "version": "2.6.2",
@@ -682,9 +674,9 @@
             "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         },
         "node_modules/@serialport/bindings/node_modules/node-abi": {
-            "version": "3.50.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.50.0.tgz",
-            "integrity": "sha512-2Gxu7Eq7vnBIRfYSmqPruEllMM14FjOQFJSoqdGWthVn+tmwEXzmdPpya6cvvwf0uZA3F5N1fMFr9mijZBplFA==",
+            "version": "3.51.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
+            "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -927,28 +919,28 @@
             "devOptional": true
         },
         "node_modules/@types/accept-language-parser": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@types/accept-language-parser/-/accept-language-parser-1.5.4.tgz",
-            "integrity": "sha512-H2I6BbxCuLreKHEZNhi20cYs2IvVr8blDDofxhnpZAWi3rOVhUPzgUC+gU0tYDwijqOqvu1GGOEvQcXi7QrtVQ==",
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/@types/accept-language-parser/-/accept-language-parser-1.5.6.tgz",
+            "integrity": "sha512-lhSQUsAhAtbKjYgaw3f0c4EQKNQHFXhX87+OXUIqDHMkycvHGaqGskSRtnzysIUiqHPqNJ4BqI5SE++drsxx6A==",
             "dev": true
         },
         "node_modules/@types/asn1": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.1.tgz",
-            "integrity": "sha512-MgrOWeBGvb9CU43AOMvrr7laqiATS4dApdqnmXl4MLxH6rSXcjSoh12y/9YGv/7Cn63cob5xQjcxVvjnOLmrmw==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha512-aMHAkHF/+RAZ5/OJsbmsXnatLHYgDwIAuVhwBybBn9aFbMr4xKyUMoCYgC5B1U3dbng+YKtsGPABlZtS9KwnMQ==",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/async": {
-            "version": "3.2.21",
-            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.21.tgz",
-            "integrity": "sha512-msYM0OYxzkwpiDJZZDo7XsYuFIpiAOh+o3hygudSpSzeW+R0DAEKZvdQriHYT95m9CvscLDg5s0Mxlrlhoy2qw=="
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.23.tgz",
+            "integrity": "sha512-/sDXs+HxCtt4/duO0AZFHs+ydQYHzd3qUybEFb+juRWQJNCFj3sYbqM2ABjWi8m7J93KXdJvIbDiARzqqIEESw=="
         },
         "node_modules/@types/aws-iot-device-sdk": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/@types/aws-iot-device-sdk/-/aws-iot-device-sdk-2.2.6.tgz",
-            "integrity": "sha512-7I8r1/VcGp1EpGEwO5K2NbDkAjVr9lUDwWxeavPVl5dt4WKJADOrtN0Wmvn56/ZNwd1470cfGPwxtBt1SItw1g==",
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/@types/aws-iot-device-sdk/-/aws-iot-device-sdk-2.2.8.tgz",
+            "integrity": "sha512-l7JWoN1vHDpvm13kppPSmfnIQbQrJK7kvG95LIKf3qYF+WJjaUDOTdMn8BA8djHWb7ASRu2D4jtuVzSTj2We6Q==",
             "dependencies": {
                 "@types/node": "*",
                 "@types/ws": "*",
@@ -965,9 +957,9 @@
             }
         },
         "node_modules/@types/body-parser": {
-            "version": "1.19.3",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
-            "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+            "version": "1.19.5",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+            "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
             "dev": true,
             "dependencies": {
                 "@types/connect": "*",
@@ -975,51 +967,51 @@
             }
         },
         "node_modules/@types/chai": {
-            "version": "4.3.8",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.8.tgz",
-            "integrity": "sha512-yW/qTM4mRBBcsA9Xw9FbcImYtFPY7sgr+G/O5RDYVmxiy9a+pE5FyoFUi8JYCZY5nicj8atrr1pcfPiYpeNGOA==",
+            "version": "4.3.10",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.10.tgz",
+            "integrity": "sha512-of+ICnbqjmFCiixUnqRulbylyXQrPqIGf/B3Jax1wIF3DvSheysQxAWvqHhZiW3IQrycvokcLcFQlveGp+vyNg==",
             "dev": true
         },
         "node_modules/@types/chai-as-promised": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.6.tgz",
-            "integrity": "sha512-cQLhk8fFarRVZAXUQV1xEnZgMoPxqKojBvRkqPCKPQCzEhpbbSKl1Uu75kDng7k5Ln6LQLUmNBjLlFthCgm1NA==",
+            "version": "7.1.8",
+            "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
+            "integrity": "sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "*"
             }
         },
         "node_modules/@types/chai-spies": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@types/chai-spies/-/chai-spies-1.0.4.tgz",
-            "integrity": "sha512-HCG1EUGpVYmmqIG9rnSIxkng/tOzARG1HmUIV5miCp55ykqxSnVj2vlXaf6nDwaMm7qzkvNe9SHW15ywPKDqTA==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/chai-spies/-/chai-spies-1.0.6.tgz",
+            "integrity": "sha512-xkk4HmhBB9OQeTAifa9MJ+6R5/Rq9+ungDe4JidZD+vqZVeiWZwc2i7/pd1ZKjyGlSBIQePoWdyUyFUGT0rv5w==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "*"
             }
         },
         "node_modules/@types/connect": {
-            "version": "3.4.36",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
-            "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/debug": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
-            "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dev": true,
             "dependencies": {
                 "@types/ms": "*"
             }
         },
         "node_modules/@types/dns-packet": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.1.tgz",
-            "integrity": "sha512-F8X3srlDYXQSVGfjAWl0lxd9mGfYtkneMA0QFQ3BFBw/BUmBlhlAbpRjmvE7LbW3wIxf01KHi20/bPstYK6ssA==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.3.tgz",
+            "integrity": "sha512-T7YsGU31kUqAeN5SzfJxapsTAVCXucSb4QsnB7wcbFBpdm7Y77r/5SBrUpdT3Ng22pgxJtLljtQtBvkP5BiSqg==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1030,9 +1022,9 @@
             "integrity": "sha512-rYzRmJSnm44Xb7FICRXEjwe/26ZiiS+VMGmuD17PevMP56cGgLEsaM955sYQW0S+K7h+mPOL70vGf1hi4WDjVA=="
         },
         "node_modules/@types/express": {
-            "version": "4.17.19",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.19.tgz",
-            "integrity": "sha512-UtOfBtzN9OvpZPPbnnYunfjM7XCI4jyk1NvnFhTVz5krYAnW4o5DCoIekvms+8ApqhB4+9wSge1kBijdfTSmfg==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
@@ -1042,9 +1034,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.37",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
-            "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+            "version": "4.17.41",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
+            "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -1054,21 +1046,21 @@
             }
         },
         "node_modules/@types/http-errors": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
-            "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+            "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
             "dev": true
         },
         "node_modules/@types/istanbul-lib-coverage": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-            "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
             "dev": true
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.13",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
-            "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
         "node_modules/@types/json5": {
@@ -1078,14 +1070,14 @@
             "dev": true
         },
         "node_modules/@types/jsrsasign": {
-            "version": "10.5.9",
-            "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.9.tgz",
-            "integrity": "sha512-MTL0Glmvs7w1qspEsHkIt0MhvcEkWCY4gwaTneG6Mca+YsTGAl18flVYVWKELOZ0ECTLJ7LargBoIuUK3tqrWg=="
+            "version": "10.5.12",
+            "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.12.tgz",
+            "integrity": "sha512-sOA+eVnHU+FziThpMhuqs/tjFKe5gHVJKIS7g1BzhXP+e2FS8OvtzM0K3IzFxVksDOr98Gz5FJiZVxZ9uFoHhw=="
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.199",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-            "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
+            "version": "4.14.201",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+            "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ=="
         },
         "node_modules/@types/lru-cache": {
             "version": "5.1.1",
@@ -1093,9 +1085,9 @@
             "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
         },
         "node_modules/@types/mime": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
-            "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "dev": true
         },
         "node_modules/@types/minimatch": {
@@ -1119,15 +1111,15 @@
             "dev": true
         },
         "node_modules/@types/ms": {
-            "version": "0.7.32",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
-            "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==",
+            "version": "0.7.34",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+            "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
             "dev": true
         },
         "node_modules/@types/multicast-dns": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.2.tgz",
-            "integrity": "sha512-re0wpYJU2SdKkBbmCh7f5zYMLFA/FCbX46DI0rRMLlkkDqhk+0bTHbYsUVZumk/43GfJehPImK9e202eSuxPKA==",
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+            "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
             "dependencies": {
                 "@types/dns-packet": "*",
                 "@types/node": "*"
@@ -1139,9 +1131,9 @@
             "integrity": "sha512-yqU2Rf94HFZqgHf6Tuyc/IqVD0l3U91KjvypSr1GtJKyrnl6L/kfnxVqN4QOwcF5Zx9tO/HKK+fozGr5AtqA+g=="
         },
         "node_modules/@types/node-fetch": {
-            "version": "2.6.6",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
-            "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -1150,28 +1142,28 @@
         },
         "node_modules/@types/node-netconf": {
             "name": "@types/netconf",
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/netconf/-/netconf-2.0.2.tgz",
-            "integrity": "sha512-SG9a517HXi52IMzcYlOXF9UaKh7YzROK0VpfzNbv9RSuHDKjgflQ+gfZZfK2hOd7csbGrQ3GJY2U8y2sUfcOog=="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/netconf/-/netconf-2.0.4.tgz",
+            "integrity": "sha512-QQIRdqsXWFwPNDYP85c7FpYPdz5tYb8Ev6U9yiHK3aOadIcl5wlZ9WwqQAAUv6yM5fbDdzqCwk5E/0bSfCbaDg=="
         },
         "node_modules/@types/proper-lockfile": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-            "integrity": "sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+            "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
             "dependencies": {
                 "@types/retry": "*"
             }
         },
         "node_modules/@types/qs": {
-            "version": "6.9.8",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-            "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+            "version": "6.9.10",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+            "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
-            "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true
         },
         "node_modules/@types/readable-stream": {
@@ -1184,19 +1176,19 @@
             }
         },
         "node_modules/@types/retry": {
-            "version": "0.12.3",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.3.tgz",
-            "integrity": "sha512-rkxEZUFIyDEZhC6EfHz6Hwos2zXewCOLBzhdgv7D55qu4OAySNwDZzxbaMpFI6XthdBa5oHhR5s6/9MSuTfw4g=="
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+            "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="
         },
         "node_modules/@types/semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw=="
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
+            "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg=="
         },
         "node_modules/@types/send": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
-            "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
             "dev": true,
             "dependencies": {
                 "@types/mime": "^1",
@@ -1204,9 +1196,9 @@
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
-            "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+            "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
             "dev": true,
             "dependencies": {
                 "@types/http-errors": "*",
@@ -1224,29 +1216,29 @@
             }
         },
         "node_modules/@types/sshpk": {
-            "version": "1.17.2",
-            "resolved": "https://registry.npmjs.org/@types/sshpk/-/sshpk-1.17.2.tgz",
-            "integrity": "sha512-eGVfOV904NrLQPcdO6UGGzbUH8gV5YG0egYD+8wkCBwZIbAYTNB8VHi29/rMrBRAhG9quIJqimugP8jiCo7t3w==",
+            "version": "1.17.4",
+            "resolved": "https://registry.npmjs.org/@types/sshpk/-/sshpk-1.17.4.tgz",
+            "integrity": "sha512-5gI/7eJn6wmkuIuFY8JZJ1g5b30H9K5U5vKrvOuYu+hoZLb2xcVEgxhYZ2Vhbs0w/ACyzyfkJq0hQtBfSCugjw==",
             "dependencies": {
                 "@types/asn1": "*",
                 "@types/node": "*"
             }
         },
         "node_modules/@types/tough-cookie": {
-            "version": "2.3.9",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.9.tgz",
-            "integrity": "sha512-jLZVDbs/2XRjcgg6X5aXlni7AC85LYOjIQ5H9Eouny0t1SDKiXWxkbTPLkMdFKYxlKVZtMstlkpU1v6d14hVbA=="
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.11.tgz",
+            "integrity": "sha512-xtFyCxnfpItBS6wRt6M+be0PzNEP6J/CqTR0mHCf/OzIbbOOh6DQ1MjiyzDrzDctzgYSmRcHH3PBvTO2hYovLg=="
         },
         "node_modules/@types/uritemplate": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.4.tgz",
-            "integrity": "sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.6.tgz",
+            "integrity": "sha512-31BMGZ8GgLxgXxLnqg4KbbyYJjU1flhTTD2+PVQStVUPXSk0IIpK0zt+tH3eLT7ZRwLnzQw6JhYx69qza3U0wg==",
             "dev": true
         },
         "node_modules/@types/url-parse": {
-            "version": "1.4.9",
-            "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.9.tgz",
-            "integrity": "sha512-pFvFO5NSAVwp8vDSENcAF13eyAcBIv/OXKvMU466CEwu/+5tyUwW05mVzhmcxaU9j9iTSYOypQqbTrYUa1emFw=="
+            "version": "1.4.11",
+            "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.11.tgz",
+            "integrity": "sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg=="
         },
         "node_modules/@types/uuid": {
             "version": "8.3.4",
@@ -1255,24 +1247,24 @@
             "dev": true
         },
         "node_modules/@types/ws": {
-            "version": "8.5.7",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.7.tgz",
-            "integrity": "sha512-6UrLjiDUvn40CMrAubXuIVtj2PEfKDffJS7ychvnPU44j+KVeXmdHHTgqcM/dxLUTHxlXHiFM8Skmb8ozGdTnQ==",
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+            "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.5.tgz",
-            "integrity": "sha512-JhtAwTRhOUcP96D0Y6KYnwig/MRQbOoLGXTON2+LlyB/N35SP9j1boai2zzwXb7ypKELXMx3DVk9UTaEq1vHEw==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.10.0.tgz",
+            "integrity": "sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.7.5",
-                "@typescript-eslint/type-utils": "6.7.5",
-                "@typescript-eslint/utils": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5",
+                "@typescript-eslint/scope-manager": "6.10.0",
+                "@typescript-eslint/type-utils": "6.10.0",
+                "@typescript-eslint/utils": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -1298,15 +1290,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.5.tgz",
-            "integrity": "sha512-bIZVSGx2UME/lmhLcjdVc7ePBwn7CLqKarUBL4me1C5feOd663liTGjMBGVcGr+BhnSLeP4SgwdvNnnkbIdkCw==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
+            "integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.7.5",
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/typescript-estree": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5",
+                "@typescript-eslint/scope-manager": "6.10.0",
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/typescript-estree": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1326,13 +1318,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.5.tgz",
-            "integrity": "sha512-GAlk3eQIwWOJeb9F7MKQ6Jbah/vx1zETSDw8likab/eFcqkjSD7BI75SDAeC5N2L0MmConMoPvTsmkrg71+B1A==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
+            "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5"
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1343,13 +1335,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.5.tgz",
-            "integrity": "sha512-Gs0qos5wqxnQrvpYv+pf3XfcRXW6jiAn9zE/K+DlmYf6FcpxeNYN0AIETaPR7rHO4K2UY+D0CIbDP9Ut0U4m1g==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.10.0.tgz",
+            "integrity": "sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.7.5",
-                "@typescript-eslint/utils": "6.7.5",
+                "@typescript-eslint/typescript-estree": "6.10.0",
+                "@typescript-eslint/utils": "6.10.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -1370,9 +1362,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.5.tgz",
-            "integrity": "sha512-WboQBlOXtdj1tDFPyIthpKrUb+kZf2VroLZhxKa/VlwLlLyqv/PwUNgL30BlTVZV1Wu4Asu2mMYPqarSO4L5ZQ==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
+            "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1383,13 +1375,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.5.tgz",
-            "integrity": "sha512-NhJiJ4KdtwBIxrKl0BqG1Ur+uw7FiOnOThcYx9DpOGJ/Abc9z2xNzLeirCG02Ig3vkvrc2qFLmYSSsaITbKjlg==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
+            "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5",
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/visitor-keys": "6.10.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1410,17 +1402,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.5.tgz",
-            "integrity": "sha512-pfRRrH20thJbzPPlPc4j0UNGvH1PjPlhlCMq4Yx7EGjV7lvEeGX0U6MJYe8+SyFutWgSHsdbJ3BXzZccYggezA==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
+            "integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.7.5",
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/typescript-estree": "6.7.5",
+                "@typescript-eslint/scope-manager": "6.10.0",
+                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/typescript-estree": "6.10.0",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -1435,12 +1427,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.7.5",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.5.tgz",
-            "integrity": "sha512-3MaWdDZtLlsexZzDSdQWsFQ9l9nL8B80Z4fImSpyllFC/KLqWQRdEcB+gGGO+N3Q2uL40EsG66wZLsohPxNXvg==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
+            "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.7.5",
+                "@typescript-eslint/types": "6.10.0",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -1455,6 +1447,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+            "dev": true
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
         },
         "node_modules/abort-controller": {
@@ -1487,9 +1485,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1539,9 +1537,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
+            "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -2010,9 +2008,9 @@
             }
         },
         "node_modules/async": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -2188,9 +2186,9 @@
             }
         },
         "node_modules/bl": {
-            "version": "6.0.7",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.7.tgz",
-            "integrity": "sha512-9FNh0IvlWSU5C9BCDhw0IovmhuqevzBX1AME7BdFHNDMfOju4NmwRWoBrfz5Srs+JNBhxfjrPLxZSnDotgSs9A==",
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.8.tgz",
+            "integrity": "sha512-HCRq8z0+3vrGCjEKrbnK6blpDZ1xzhfZKCCuyvPC7upGcfXZSmaCumpVao/jC8o1hs/fOqJoCSPMabl+CQTPXg==",
             "dependencies": {
                 "buffer": "^6.0.3",
                 "inherits": "^2.0.4",
@@ -2585,12 +2583,16 @@
             "dev": true
         },
         "node_modules/builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+            "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
             "dev": true,
+            "peer": true,
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/builtin-status-codes": {
@@ -2673,12 +2675,13 @@
             "dev": true
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2769,9 +2772,9 @@
             }
         },
         "node_modules/chai-spies": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.0.0.tgz",
-            "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.1.0.tgz",
+            "integrity": "sha512-ikaUhQvQWchRYj2K54itFp3nrcxaFRpSDQxDlRzSn9aWgu9Pi7lD8yFxTso4WnQ39+WZ69oB/qOvqp+isJIIWA==",
             "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
@@ -3748,26 +3751,26 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
-            "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
             "dev": true,
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.0",
                 "arraybuffer.prototype.slice": "^1.0.2",
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.5",
                 "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
                 "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.1",
+                "get-intrinsic": "^1.2.2",
                 "get-symbol-description": "^1.0.0",
                 "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
-                "has": "^1.0.3",
                 "has-property-descriptors": "^1.0.0",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0",
                 "internal-slot": "^1.0.5",
                 "is-array-buffer": "^3.0.2",
                 "is-callable": "^1.2.7",
@@ -3777,7 +3780,7 @@
                 "is-string": "^1.0.7",
                 "is-typed-array": "^1.1.12",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.3",
+                "object-inspect": "^1.13.1",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
                 "regexp.prototype.flags": "^1.5.1",
@@ -3791,7 +3794,7 @@
                 "typed-array-byte-offset": "^1.0.0",
                 "typed-array-length": "^1.0.4",
                 "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.11"
+                "which-typed-array": "^1.1.13"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3801,26 +3804,26 @@
             }
         },
         "node_modules/es-set-tostringtag": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-            "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.1.3",
-                "has": "^1.0.3",
-                "has-tostringtag": "^1.0.0"
+                "get-intrinsic": "^1.2.2",
+                "has-tostringtag": "^1.0.0",
+                "hasown": "^2.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/es-shim-unscopables": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-            "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+            "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
             "dev": true,
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.0"
             }
         },
         "node_modules/es-to-primitive": {
@@ -3867,18 +3870,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
+            "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.51.0",
-                "@humanwhocodes/config-array": "^0.11.11",
+                "@eslint/eslintrc": "^2.1.3",
+                "@eslint/js": "8.53.0",
+                "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -4027,9 +4031,9 @@
             }
         },
         "node_modules/eslint-plugin-es-x": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
-            "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.3.0.tgz",
+            "integrity": "sha512-W9zIs+k00I/I13+Bdkl/zG1MEO07G97XjUSQuH117w620SJ6bHtLUmoMvkGA2oYnI/gNdr+G7BONLyYnFaLLEQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -4047,26 +4051,26 @@
             }
         },
         "node_modules/eslint-plugin-import": {
-            "version": "2.28.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-            "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
+            "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
             "dev": true,
             "dependencies": {
-                "array-includes": "^3.1.6",
-                "array.prototype.findlastindex": "^1.2.2",
-                "array.prototype.flat": "^1.3.1",
-                "array.prototype.flatmap": "^1.3.1",
+                "array-includes": "^3.1.7",
+                "array.prototype.findlastindex": "^1.2.3",
+                "array.prototype.flat": "^1.3.2",
+                "array.prototype.flatmap": "^1.3.2",
                 "debug": "^3.2.7",
                 "doctrine": "^2.1.0",
-                "eslint-import-resolver-node": "^0.3.7",
+                "eslint-import-resolver-node": "^0.3.9",
                 "eslint-module-utils": "^2.8.0",
-                "has": "^1.0.3",
-                "is-core-module": "^2.13.0",
+                "hasown": "^2.0.0",
+                "is-core-module": "^2.13.1",
                 "is-glob": "^4.0.3",
                 "minimatch": "^3.1.2",
-                "object.fromentries": "^2.0.6",
-                "object.groupby": "^1.0.0",
-                "object.values": "^1.1.6",
+                "object.fromentries": "^2.0.7",
+                "object.groupby": "^1.0.1",
+                "object.values": "^1.1.7",
                 "semver": "^6.3.1",
                 "tsconfig-paths": "^3.14.2"
             },
@@ -4108,9 +4112,9 @@
             }
         },
         "node_modules/eslint-plugin-n": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.2.0.tgz",
-            "integrity": "sha512-AQER2jEyQOt1LG6JkGJCCIFotzmlcCZFur2wdKrp1JX2cNotC7Ae0BcD/4lLv3lUAArM9uNS8z/fsvXTd0L71g==",
+            "version": "16.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
+            "integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -4119,6 +4123,7 @@
                 "eslint-plugin-es-x": "^7.1.0",
                 "get-tsconfig": "^4.7.0",
                 "ignore": "^5.2.4",
+                "is-builtin-module": "^3.2.1",
                 "is-core-module": "^2.12.1",
                 "minimatch": "^3.1.2",
                 "resolve": "^1.22.2",
@@ -4550,9 +4555,9 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -4770,9 +4775,9 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-            "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "dependencies": {
                 "flatted": "^3.2.9",
@@ -4780,7 +4785,7 @@
                 "rimraf": "^3.0.2"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": "^10.12.0 || >=12.0.0"
             }
         },
         "node_modules/flatted": {
@@ -5023,14 +5028,14 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
+                "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5209,6 +5214,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
             "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -5252,11 +5258,11 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
+                "get-intrinsic": "^1.2.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5346,6 +5352,17 @@
             "dependencies": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/he": {
@@ -5598,13 +5615,13 @@
             }
         },
         "node_modules/internal-slot": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-            "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.2.0",
-                "has": "^1.0.3",
+                "get-intrinsic": "^1.2.2",
+                "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
             },
             "engines": {
@@ -5620,12 +5637,11 @@
             }
         },
         "node_modules/ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-            "dev": true,
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+            "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10"
             }
         },
         "node_modules/is-absolute-url": {
@@ -5710,6 +5726,22 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
+        "node_modules/is-builtin-module": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+            "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "builtin-modules": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -5722,11 +5754,11 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-            "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5983,9 +6015,9 @@
             "dev": true
         },
         "node_modules/istanbul-lib-coverage": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-            "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -6890,9 +6922,9 @@
             }
         },
         "node_modules/nise": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-            "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
+            "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^2.0.0",
@@ -8235,9 +8267,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -8884,6 +8916,15 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/psl": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -8919,9 +8960,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
             }
@@ -9565,6 +9606,20 @@
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
             "optional": true
         },
+        "node_modules/set-function-length": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/set-function-name": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -9749,6 +9804,7 @@
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
             "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+            "deprecated": "16.1.1",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.8.3",
@@ -9852,9 +9908,9 @@
             }
         },
         "node_modules/sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -10533,6 +10589,15 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/tslint/node_modules/builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/tslint/node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -11014,9 +11079,9 @@
             }
         },
         "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -11169,12 +11234,12 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.4",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
                 "has-tostringtag": "^1.0.0"
@@ -11310,9 +11375,9 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yaml": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
-            "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+            "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
             "dev": true,
             "engines": {
                 "node": ">= 14"
@@ -11392,11 +11457,11 @@
         },
         "packages/binding-coap": {
             "name": "@node-wot/binding-coap",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "@types/node": "16.18.35",
                 "coap": "^1.3.0",
                 "multicast-dns": "^7.2.5",
@@ -11408,22 +11473,22 @@
         },
         "packages/binding-file": {
             "name": "@node-wot/binding-file",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10"
+                "@node-wot/core": "0.8.11"
             },
             "devDependencies": {
-                "@node-wot/td-tools": "0.8.10"
+                "@node-wot/td-tools": "0.8.11"
             }
         },
         "packages/binding-http": {
             "name": "@node-wot/binding-http",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "@types/eventsource": "1.1.10",
                 "accept-language-parser": "1.5.0",
                 "basic-auth": "2.0.1",
@@ -11448,22 +11513,22 @@
         },
         "packages/binding-mbus": {
             "name": "@node-wot/binding-mbus",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "node-mbus": "^2.1.0",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
             }
         },
         "packages/binding-modbus": {
             "name": "@node-wot/binding-modbus",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "modbus-serial": "8.0.3",
                 "rxjs": "5.5.11",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
@@ -11471,11 +11536,11 @@
         },
         "packages/binding-mqtt": {
             "name": "@node-wot/binding-mqtt",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "aedes": "^0.46.2",
                 "mqtt": "^4.2.8",
                 "rxjs": "5.5.11"
@@ -11483,11 +11548,11 @@
         },
         "packages/binding-netconf": {
             "name": "@node-wot/binding-netconf",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "@types/node-netconf": "npm:@types/netconf@^2.0.0",
                 "@types/url-parse": "^1.4.3",
                 "case-1.5.3": "npm:case@^1.5.3",
@@ -11497,11 +11562,11 @@
         },
         "packages/binding-opcua": {
             "name": "@node-wot/binding-opcua",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "ajv": "^8.11.0",
                 "ajv-formats": "^2.1.1",
                 "node-opcua": "2.113.0",
@@ -11535,19 +11600,19 @@
         },
         "packages/binding-websockets": {
             "name": "@node-wot/binding-websockets",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-http": "0.8.10",
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/binding-http": "0.8.11",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "slugify": "^1.4.5",
                 "ws": "^7.5.4"
             }
         },
         "packages/browser-bundle": {
             "name": "@node-wot/browser-bundle",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "events": "^2.1.0",
@@ -11555,26 +11620,26 @@
                 "resolve": "^1.1.7"
             },
             "devDependencies": {
-                "@node-wot/binding-http": "0.8.10",
-                "@node-wot/binding-websockets": "0.8.10",
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/binding-http": "0.8.11",
+                "@node-wot/binding-websockets": "0.8.11",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "browserify": "^17.0.0",
                 "readable-stream4": "npm:readable-stream@^4.0.0"
             }
         },
         "packages/cli": {
             "name": "@node-wot/cli",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.10",
-                "@node-wot/binding-file": "0.8.10",
-                "@node-wot/binding-http": "0.8.10",
-                "@node-wot/binding-mqtt": "0.8.10",
-                "@node-wot/binding-websockets": "0.8.10",
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/binding-coap": "0.8.11",
+                "@node-wot/binding-file": "0.8.11",
+                "@node-wot/binding-http": "0.8.11",
+                "@node-wot/binding-mqtt": "0.8.11",
+                "@node-wot/binding-websockets": "0.8.11",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "@types/lodash": "^4.14.199",
                 "ajv": "^8.11.0",
                 "commander": "^9.1.0",
@@ -11642,10 +11707,10 @@
         },
         "packages/core": {
             "name": "@node-wot/core",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/td-tools": "0.8.11",
                 "@petamoriken/float16": "^3.1.1",
                 "ajv": "^8.11.0",
                 "cbor": "^8.1.0",
@@ -11662,22 +11727,22 @@
         },
         "packages/examples": {
             "name": "@node-wot/examples",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.10",
-                "@node-wot/binding-file": "0.8.10",
-                "@node-wot/binding-http": "0.8.10",
-                "@node-wot/binding-mqtt": "0.8.10",
-                "@node-wot/binding-opcua": "0.8.10",
-                "@node-wot/core": "0.8.10",
-                "@node-wot/td-tools": "0.8.10",
+                "@node-wot/binding-coap": "0.8.11",
+                "@node-wot/binding-file": "0.8.11",
+                "@node-wot/binding-http": "0.8.11",
+                "@node-wot/binding-mqtt": "0.8.11",
+                "@node-wot/binding-opcua": "0.8.11",
+                "@node-wot/core": "0.8.11",
+                "@node-wot/td-tools": "0.8.11",
                 "rxjs": "5.5.11"
             }
         },
         "packages/td-tools": {
             "name": "@node-wot/td-tools",
-            "version": "0.8.10",
+            "version": "0.8.11",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "ajv": "^8.11.0",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-coap",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "CoAP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/coap.js",
     "types": "dist/coap.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "@types/node": "16.18.35",
         "coap": "^1.3.0",
         "multicast-dns": "^7.2.5",

--- a/packages/binding-file/package.json
+++ b/packages/binding-file/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-file",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "File client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,10 +14,10 @@
     "main": "dist/file.js",
     "types": "dist/file.d.ts",
     "devDependencies": {
-        "@node-wot/td-tools": "0.8.10"
+        "@node-wot/td-tools": "0.8.11"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.10"
+        "@node-wot/core": "0.8.11"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-http",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "HTTP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -28,8 +28,8 @@
         "timekeeper": "^2.2.0"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "@types/eventsource": "1.1.10",
         "accept-language-parser": "1.5.0",
         "basic-auth": "2.0.1",

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mbus",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "M-Bus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/mbus.js",
     "types": "dist/mbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "node-mbus": "^2.1.0",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
     },

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-modbus",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "Modbus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "contributors": [
@@ -17,8 +17,8 @@
     "main": "dist/modbus.js",
     "types": "dist/modbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "modbus-serial": "8.0.3",
         "rxjs": "5.5.11",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mqtt",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "MQTT binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/mqtt.js",
     "types": "dist/mqtt.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "aedes": "^0.46.2",
         "mqtt": "^4.2.8",
         "rxjs": "5.5.11"

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-netconf",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "NetConf client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/netconf.js",
     "types": "dist/netconf.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "@types/node-netconf": "npm:@types/netconf@^2.0.0",
         "@types/url-parse": "^1.4.3",
         "case-1.5.3": "npm:case@^1.5.3",

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-opcua",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "opcua client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -18,8 +18,8 @@
         "should": "^13.2.3"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "node-opcua": "2.113.0",

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-websockets",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "WebSockets client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -15,9 +15,9 @@
     "types": "dist/ws.d.ts",
     "browser": "dist/ws-browser.js",
     "dependencies": {
-        "@node-wot/binding-http": "0.8.10",
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/binding-http": "0.8.11",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "slugify": "^1.4.5",
         "ws": "^7.5.4"
     },

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/browser-bundle",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "A node-wot bundle that can run in a web browser",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -13,10 +13,10 @@
     ],
     "main": "dist/wot-bundle.min.js",
     "devDependencies": {
-        "@node-wot/binding-http": "0.8.10",
-        "@node-wot/binding-websockets": "0.8.10",
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/binding-http": "0.8.11",
+        "@node-wot/binding-websockets": "0.8.11",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "browserify": "^17.0.0",
         "readable-stream4": "npm:readable-stream@^4.0.0"
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/cli",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "servient command line interface",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -20,13 +20,13 @@
         "ts-node": "10.1.0"
     },
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.10",
-        "@node-wot/binding-file": "0.8.10",
-        "@node-wot/binding-http": "0.8.10",
-        "@node-wot/binding-mqtt": "0.8.10",
-        "@node-wot/binding-websockets": "0.8.10",
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/binding-coap": "0.8.11",
+        "@node-wot/binding-file": "0.8.11",
+        "@node-wot/binding-http": "0.8.11",
+        "@node-wot/binding-mqtt": "0.8.11",
+        "@node-wot/binding-websockets": "0.8.11",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "@types/lodash": "^4.14.199",
         "ajv": "^8.11.0",
         "commander": "^9.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/core",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "W3C Web of Things (WoT) Servient framework",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -20,7 +20,7 @@
         "@types/uuid": "^8.3.1"
     },
     "dependencies": {
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/td-tools": "0.8.11",
         "@petamoriken/float16": "^3.1.1",
         "ajv": "^8.11.0",
         "cbor": "^8.1.0",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,19 +1,19 @@
 {
     "name": "@node-wot/examples",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "private": true,
     "description": "Examples for node-wot (not published)",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
     "repository": "https://github.com/eclipse-thingweb/node-wot/tree/master/packages/examples",
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.10",
-        "@node-wot/binding-file": "0.8.10",
-        "@node-wot/binding-http": "0.8.10",
-        "@node-wot/binding-mqtt": "0.8.10",
-        "@node-wot/binding-opcua": "0.8.10",
-        "@node-wot/core": "0.8.10",
-        "@node-wot/td-tools": "0.8.10",
+        "@node-wot/binding-coap": "0.8.11",
+        "@node-wot/binding-file": "0.8.11",
+        "@node-wot/binding-http": "0.8.11",
+        "@node-wot/binding-mqtt": "0.8.11",
+        "@node-wot/binding-opcua": "0.8.11",
+        "@node-wot/core": "0.8.11",
+        "@node-wot/td-tools": "0.8.11",
         "rxjs": "5.5.11"
     },
     "scripts": {

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/td-tools",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "W3C Web of Things (WoT) Thing Description parser, serializer, and other tools",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",


### PR DESCRIPTION
FYI: Every time we update the node-wot package versions we also newly create `package-lock.json` to update dependencies.
Hence on can see many changes for `package-lock.json` ...