### PR TITLE
chore: update Scripting API and TD/TM NPM versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
                 "tslint": "5.12.1",
                 "typescript": "4.7.4",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -11267,10 +11267,9 @@
             "dev": true
         },
         "node_modules/wot-thing-description-types": {
-            "version": "1.1.0-05-July-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-05-July-2023.tgz",
-            "integrity": "sha512-s24umjivmgeJuW93siBf6SRCSh+5OBfXoO5x1tSPxuXtQ2GCishGyA/BHohMODzrwDz8EuEpnF7P/3T3pVI5ew==",
-            "dev": true
+            "version": "1.1.0-09-November-2023",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
+            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
         },
         "node_modules/wot-thing-model-types": {
             "version": "1.1.0-09-November-2023",
@@ -11278,12 +11277,11 @@
             "integrity": "sha512-BwmZGEG5VCth34RwXbQutFre7dcSanm1OhYve6lTxuGyqeRAQsj33CUrN5PjU5LSs68Xubm0FbKJZPvWGFa6LA=="
         },
         "node_modules/wot-typescript-definitions": {
-            "version": "0.8.0-SNAPSHOT.27",
-            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.27.tgz",
-            "integrity": "sha512-3E6mpZNJu7ya6GAB/65qc7/pmgFnOZ6mSpp+liyEEYjuQiR7oxzr/cUtSbHWK/ynUI3J3T8RkzQn+N73rKvGfQ==",
-            "dev": true,
+            "version": "0.8.0-SNAPSHOT.29",
+            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
+            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
             "dependencies": {
-                "wot-thing-description-types": "1.1.0-05-July-2023"
+                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         },
         "node_modules/wrap-ansi": {
@@ -11473,19 +11471,6 @@
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
             }
         },
-        "packages/binding-coap/node_modules/wot-thing-description-types": {
-            "version": "1.1.0-09-November-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
-            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
-        },
-        "packages/binding-coap/node_modules/wot-typescript-definitions": {
-            "version": "0.8.0-SNAPSHOT.29",
-            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
-            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
-            "dependencies": {
-                "wot-thing-description-types": "1.1.0-09-November-2023"
-            }
-        },
         "packages/binding-file": {
             "name": "@node-wot/binding-file",
             "version": "0.8.11",
@@ -11537,19 +11522,6 @@
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
             }
         },
-        "packages/binding-mbus/node_modules/wot-thing-description-types": {
-            "version": "1.1.0-09-November-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
-            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
-        },
-        "packages/binding-mbus/node_modules/wot-typescript-definitions": {
-            "version": "0.8.0-SNAPSHOT.29",
-            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
-            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
-            "dependencies": {
-                "wot-thing-description-types": "1.1.0-09-November-2023"
-            }
-        },
         "packages/binding-modbus": {
             "name": "@node-wot/binding-modbus",
             "version": "0.8.11",
@@ -11560,19 +11532,6 @@
                 "modbus-serial": "8.0.3",
                 "rxjs": "5.5.11",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
-            }
-        },
-        "packages/binding-modbus/node_modules/wot-thing-description-types": {
-            "version": "1.1.0-09-November-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
-            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
-        },
-        "packages/binding-modbus/node_modules/wot-typescript-definitions": {
-            "version": "0.8.0-SNAPSHOT.29",
-            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
-            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
-            "dependencies": {
-                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         },
         "packages/binding-mqtt": {
@@ -11793,19 +11752,6 @@
                 "url-toolkit": "2.1.6",
                 "wot-thing-model-types": "1.1.0-09-November-2023",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
-            }
-        },
-        "packages/td-tools/node_modules/wot-thing-description-types": {
-            "version": "1.1.0-09-November-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
-            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
-        },
-        "packages/td-tools/node_modules/wot-typescript-definitions": {
-            "version": "0.8.0-SNAPSHOT.29",
-            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
-            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
-            "dependencies": {
-                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11269,17 +11269,19 @@
         "node_modules/wot-thing-description-types": {
             "version": "1.1.0-05-July-2023",
             "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-05-July-2023.tgz",
-            "integrity": "sha512-s24umjivmgeJuW93siBf6SRCSh+5OBfXoO5x1tSPxuXtQ2GCishGyA/BHohMODzrwDz8EuEpnF7P/3T3pVI5ew=="
+            "integrity": "sha512-s24umjivmgeJuW93siBf6SRCSh+5OBfXoO5x1tSPxuXtQ2GCishGyA/BHohMODzrwDz8EuEpnF7P/3T3pVI5ew==",
+            "dev": true
         },
         "node_modules/wot-thing-model-types": {
-            "version": "1.1.0-05-July-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-05-July-2023.tgz",
-            "integrity": "sha512-e52eHHzwRJ3Rz3QFZNvZeSlXOpdYqs/3Jk114mUbtH54nsB9A//1gmT3H7w9+PJ2q+NBHF/pPHc+vr10V76FKg=="
+            "version": "1.1.0-09-November-2023",
+            "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-09-November-2023.tgz",
+            "integrity": "sha512-BwmZGEG5VCth34RwXbQutFre7dcSanm1OhYve6lTxuGyqeRAQsj33CUrN5PjU5LSs68Xubm0FbKJZPvWGFa6LA=="
         },
         "node_modules/wot-typescript-definitions": {
             "version": "0.8.0-SNAPSHOT.27",
             "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.27.tgz",
             "integrity": "sha512-3E6mpZNJu7ya6GAB/65qc7/pmgFnOZ6mSpp+liyEEYjuQiR7oxzr/cUtSbHWK/ynUI3J3T8RkzQn+N73rKvGfQ==",
+            "dev": true,
             "dependencies": {
                 "wot-thing-description-types": "1.1.0-05-July-2023"
             }
@@ -11468,7 +11470,20 @@
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+            }
+        },
+        "packages/binding-coap/node_modules/wot-thing-description-types": {
+            "version": "1.1.0-09-November-2023",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
+            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
+        },
+        "packages/binding-coap/node_modules/wot-typescript-definitions": {
+            "version": "0.8.0-SNAPSHOT.29",
+            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
+            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
+            "dependencies": {
+                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         },
         "packages/binding-file": {
@@ -11519,7 +11534,20 @@
                 "@node-wot/core": "0.8.11",
                 "@node-wot/td-tools": "0.8.11",
                 "node-mbus": "^2.1.0",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+            }
+        },
+        "packages/binding-mbus/node_modules/wot-thing-description-types": {
+            "version": "1.1.0-09-November-2023",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
+            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
+        },
+        "packages/binding-mbus/node_modules/wot-typescript-definitions": {
+            "version": "0.8.0-SNAPSHOT.29",
+            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
+            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
+            "dependencies": {
+                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         },
         "packages/binding-modbus": {
@@ -11531,7 +11559,20 @@
                 "@node-wot/td-tools": "0.8.11",
                 "modbus-serial": "8.0.3",
                 "rxjs": "5.5.11",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+            }
+        },
+        "packages/binding-modbus/node_modules/wot-thing-description-types": {
+            "version": "1.1.0-09-November-2023",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
+            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
+        },
+        "packages/binding-modbus/node_modules/wot-typescript-definitions": {
+            "version": "0.8.0-SNAPSHOT.29",
+            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
+            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
+            "dependencies": {
+                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         },
         "packages/binding-mqtt": {
@@ -11750,8 +11791,21 @@
                 "is-absolute-url": "3.0.3",
                 "json-placeholder-replacer": "^1.0.35",
                 "url-toolkit": "2.1.6",
-                "wot-thing-model-types": "1.1.0-05-July-2023",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+                "wot-thing-model-types": "1.1.0-09-November-2023",
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+            }
+        },
+        "packages/td-tools/node_modules/wot-thing-description-types": {
+            "version": "1.1.0-09-November-2023",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
+            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA=="
+        },
+        "packages/td-tools/node_modules/wot-typescript-definitions": {
+            "version": "0.8.0-SNAPSHOT.29",
+            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
+            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
+            "dependencies": {
+                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
         "tslint": "5.12.1",
         "typescript": "4.7.4",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     }
 }

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -22,7 +22,7 @@
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -17,7 +17,7 @@
         "@node-wot/core": "0.8.11",
         "@node-wot/td-tools": "0.8.11",
         "node-mbus": "^2.1.0",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -21,7 +21,7 @@
         "@node-wot/td-tools": "0.8.11",
         "modbus-serial": "8.0.3",
         "rxjs": "5.5.11",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -23,60 +23,24 @@ import { createLoggers } from "./logger";
 
 const { debug } = createLoggers("core", "wot-impl");
 
-export class ThingDiscoveryImpl implements WoT.ThingDiscovery {
-    filter?: WoT.ThingFilter;
-    active: boolean;
-    done: boolean;
-    error?: Error;
-    constructor(filter?: WoT.ThingFilter) {
-        this.filter = filter;
-        this.active = false;
-        this.done = false;
-        this.error = new Error("not implemented");
-    }
-
-    start(): void {
-        this.active = true;
-    }
-
-    next(): Promise<WoT.ThingDescription> {
-        return new Promise<WoT.ThingDescription>((resolve, reject) => {
-            reject(this.error); // not implemented
-        });
-    }
-
-    stop(): void {
-        this.active = false;
-        this.done = false;
-    }
-}
-/**
- * wot-type-definitions does not contain a implementation of Discovery method enums
- * so we need to create them here. Sadly, we should keep this enum in sync with
- * WoT.DiscoveryMethod
- */
-export enum DiscoveryMethod {
-    /** does not provide any restriction */
-    "any",
-    /** for discovering Things defined in the same device */
-    "local",
-    /** for discovery based on a service provided by a directory or repository of Things  */
-    "directory",
-    /** for discovering Things in the device's network by using a supported multicast protocol  */
-    "multicast",
-}
 export default class WoTImpl {
     private srv: Servient;
-    DiscoveryMethod: typeof WoT.DiscoveryMethod;
     constructor(srv: Servient) {
         this.srv = srv;
-        // force casting cause tsc does not allow to use DiscoveryMethod as WoT.DiscoveryMethod even if they are the same
-        this.DiscoveryMethod = DiscoveryMethod as unknown as typeof WoT.DiscoveryMethod;
     }
 
     /** @inheritDoc */
-    discover(filter?: WoT.ThingFilter): WoT.ThingDiscovery {
-        return new ThingDiscoveryImpl(filter);
+    async discover(filter?: WoT.ThingFilter): Promise<WoT.ThingDiscoveryProcess> {
+        throw new Error("not implemented");
+    }
+
+    /** @inheritDoc */
+    async exploreDirectory(url: string, filter?: WoT.ThingFilter): Promise<WoT.ThingDiscoveryProcess> {
+        throw new Error("not implemented");
+    }
+
+    async requestThingDescription(url: string): Promise<WoT.ThingDescription> {
+        throw new Error("not implemented");
     }
 
     /** @inheritDoc */

--- a/packages/examples/src/security/oauth/package.json
+++ b/packages/examples/src/security/oauth/package.json
@@ -19,6 +19,6 @@
         "ts-node": "10.1.0",
         "typescript": "4.7.4",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     }
 }

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -20,8 +20,8 @@
         "is-absolute-url": "3.0.3",
         "json-placeholder-replacer": "^1.0.35",
         "url-toolkit": "2.1.6",
-        "wot-thing-model-types": "1.1.0-05-July-2023",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.27"
+        "wot-thing-model-types": "1.1.0-09-November-2023",
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     },
     "scripts": {
         "build": "tsc -b && webpack",


### PR DESCRIPTION
- wot-typescript-definitions@0.8.0-SNAPSHOT.29
- wot-thing-description-types@1.1.0-09-November-2023
- wot-thing-model-types@1.1.0-09-November-2023

Note:  adds _empty_ discovery methods:
- `discover(...)`
- `exploreDirectory(...)`
- `requestThingDescription(...)`