### PR TITLE
feat: add initial requestThingDescription implementation

### DIFF
--- a/packages/binding-coap/src/coap-client.ts
+++ b/packages/binding-coap/src/coap-client.ts
@@ -183,6 +183,24 @@ export default class CoapClient implements ProtocolClient {
         });
     }
 
+    /**
+     * @inheritdoc
+     */
+    requestThingDescription(uri: string): Promise<Content> {
+        const options: CoapRequestParams = this.uriToOptions(uri);
+        const req = this.agent.request(options);
+
+        req.setOption("Accept", "application/td+json");
+        return new Promise<Content>((resolve, reject) => {
+            req.on("response", (res: IncomingMessage) => {
+                const contentType = (res.headers["Content-Format"] as string) ?? "application/td+json";
+                resolve(new Content(contentType, Readable.from(res.payload)));
+            });
+            req.on("error", (err: Error) => reject(err));
+            req.end();
+        });
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }

--- a/packages/binding-coap/src/coaps-client.ts
+++ b/packages/binding-coap/src/coaps-client.ts
@@ -139,6 +139,23 @@ export default class CoapsClient implements ProtocolClient {
         });
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        const response = await coaps.request(uri, "get", undefined, {
+            // FIXME: Add accept option
+            //       Currently not supported by node-coap-client
+        });
+
+        // TODO: Respect Content-Format in response.
+        //       Currently not really well supported by node-coap-client
+        const contentType = "application/td+json";
+        const payload = response.payload ?? Buffer.alloc(0);
+
+        return new Content(contentType, Readable.from(payload));
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -72,6 +72,13 @@ export default class FileClient implements ProtocolClient {
         throw new Error("FileClient does not implement unlink");
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Not implemented");
+    }
+
     public async subscribeResource(
         form: Form,
         next: (value: Content) => void,

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -28,7 +28,7 @@ const { debug, warn } = createLoggers("binding-file", "file-client");
  * Used to determine the Content-Type of a file from the extension in its
  * {@link filePath} if no explicit Content-Type is defined.
  *
- * @param filepath The file paththe Content-Type is determined for.
+ * @param filepath The file path the Content-Type is determined for.
  * @returns An appropriate Content-Type or `application/octet-stream` as a fallback.
  */
 function mapFileExtensionToContentType(filepath: string) {

--- a/packages/binding-file/src/file-client.ts
+++ b/packages/binding-file/src/file-client.ts
@@ -64,7 +64,7 @@ export default class FileClient implements ProtocolClient {
     }
 
     public async readResource(form: Form): Promise<Content> {
-        const filepath = form.href.split("//")[1];
+        const filepath = new URL(form.href).pathname;
         return this.readFile(filepath, form.contentType);
     }
 

--- a/packages/binding-http/src/http-client-impl.ts
+++ b/packages/binding-http/src/http-client-impl.ts
@@ -212,6 +212,18 @@ export default class HttpClient implements ProtocolClient {
         }
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        const headers: HeadersInit = {
+            Accept: "application/td+json",
+        };
+        const response = await fetch(uri, { headers });
+        const body = ProtocolHelpers.toNodeStream(response.body as Readable);
+        return new Content(response.headers.get("content-type") ?? "application/td+json", body);
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }

--- a/packages/binding-mbus/src/mbus-client.ts
+++ b/packages/binding-mbus/src/mbus-client.ts
@@ -61,6 +61,13 @@ export default class MBusClient implements ProtocolClient {
         throw new Error("Method not implemented.");
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented");
+    }
+
     async start(): Promise<void> {
         // do nothing
     }

--- a/packages/binding-modbus/src/modbus-client.ts
+++ b/packages/binding-modbus/src/modbus-client.ts
@@ -131,6 +131,13 @@ export default class ModbusClient implements ProtocolClient {
         });
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented");
+    }
+
     async start(): Promise<void> {
         // do nothing
     }

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -161,6 +161,13 @@ export default class MqttClient implements ProtocolClient {
         }
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented");
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }

--- a/packages/binding-netconf/src/netconf-client.ts
+++ b/packages/binding-netconf/src/netconf-client.ts
@@ -155,6 +155,13 @@ export default class NetconfClient implements ProtocolClient {
         throw unimplementedError;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented");
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -430,6 +430,13 @@ export class OPCUAProtocolClient implements ProtocolClient {
         });
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented");
+    }
+
     start(): Promise<void> {
         debug("start: Sorry not implemented");
         throw new Error("Method not implemented.");

--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -66,6 +66,13 @@ export default class WebSocketClient implements ProtocolClient {
         throw new Error("Websocket client does not implement subscribeResource");
     }
 
+    /**
+     * @inheritdoc
+     */
+    public async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented");
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }

--- a/packages/core/src/protocol-interfaces.ts
+++ b/packages/core/src/protocol-interfaces.ts
@@ -66,6 +66,16 @@ export interface ProtocolClient {
         complete?: () => void
     ): Promise<Subscription>;
 
+    /**
+     * Requests a single Thing Description from a given {@link uri}.
+     *
+     * The result is returned asynchronously as {@link Content}, which has to
+     * be deserialized and validated by the upper layers of the implementation.
+     *
+     * @param uri
+     */
+    requestThingDescription(uri: string): Promise<Content>;
+
     /** start the client (ensure it is ready to send requests) */
     start(): Promise<void>;
     /** stop the client */

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -21,6 +21,7 @@ import ConsumedThing from "./consumed-thing";
 import Helpers from "./helpers";
 import { createLoggers } from "./logger";
 import ContentManager from "./content-serdes";
+import TDSchema from "wot-thing-description-types/schema/td-json-schema-validation.json";
 
 const { debug } = createLoggers("core", "wot-impl");
 
@@ -44,12 +45,11 @@ export default class WoTImpl {
     async requestThingDescription(url: string): Promise<WoT.ThingDescription> {
         const uriScheme = new URL(url).protocol.split(":")[0];
         const client = this.srv.getClientFor(uriScheme);
-        const result = await client.requestThingDescription(url);
+        const content = await client.requestThingDescription(url);
 
-        const value = ContentManager.contentToValue({ type: result.type, body: await result.toBuffer() }, {});
+        const value = ContentManager.contentToValue({ type: content.type, body: await content.toBuffer() }, TDSchema);
 
         if (value instanceof Object) {
-            // TODO: Add validation step
             return value as WoT.ThingDescription;
         }
 

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -20,6 +20,7 @@ import ExposedThing from "./exposed-thing";
 import ConsumedThing from "./consumed-thing";
 import Helpers from "./helpers";
 import { createLoggers } from "./logger";
+import ContentManager from "./content-serdes";
 
 const { debug } = createLoggers("core", "wot-impl");
 
@@ -39,8 +40,20 @@ export default class WoTImpl {
         throw new Error("not implemented");
     }
 
+    /** @inheritDoc */
     async requestThingDescription(url: string): Promise<WoT.ThingDescription> {
-        throw new Error("not implemented");
+        const uriScheme = new URL(url).protocol.split(":")[0];
+        const client = this.srv.getClientFor(uriScheme);
+        const result = await client.requestThingDescription(url);
+
+        const value = ContentManager.contentToValue({ type: result.type, body: await result.toBuffer() }, {});
+
+        if (value instanceof Object) {
+            // TODO: Add validation step
+            return value as WoT.ThingDescription;
+        }
+
+        throw new Error("Not found.");
     }
 
     /** @inheritDoc */

--- a/packages/core/src/wot-impl.ts
+++ b/packages/core/src/wot-impl.ts
@@ -43,7 +43,7 @@ export default class WoTImpl {
 
     /** @inheritDoc */
     async requestThingDescription(url: string): Promise<WoT.ThingDescription> {
-        const uriScheme = new URL(url).protocol.split(":")[0];
+        const uriScheme = Helpers.extractScheme(url);
         const client = this.srv.getClientFor(uriScheme);
         const content = await client.requestThingDescription(url);
 

--- a/packages/core/test/ClientTest.ts
+++ b/packages/core/test/ClientTest.ts
@@ -156,6 +156,10 @@ class TDClient implements ProtocolClient {
         return new Subscription();
     }
 
+    async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }
@@ -230,6 +234,10 @@ class TrapClient implements ProtocolClient {
         return new Subscription();
     }
 
+    async requestThingDescription(uri: string): Promise<Content> {
+        throw new Error("Method not implemented.");
+    }
+
     public async start(): Promise<void> {
         // do nothing
     }
@@ -290,6 +298,10 @@ class TestProtocolClient implements ProtocolClient {
         error?: (error: Error) => void,
         complete?: () => void
     ): Promise<Subscription> {
+        throw new Error("Method not implemented.");
+    }
+
+    async requestThingDescription(uri: string): Promise<Content> {
         throw new Error("Method not implemented.");
     }
 


### PR DESCRIPTION
This PR adds an initial implementation for the `requestThingDescription` method.

The implementation details probably still need some additional discussion – looking forward to your feedback here :) For now, I extended the `ProtocolClient` interface with a new `requestThingDescription` method that is expected to return a `Content` object that is deserialized and (supposed to be ) validated by the `WoT` implementation.

I think this latter part also touches #1055 – in my opinion, there should be some validation happening so that library users can be sure that they always receive a valid Thing Description. Maybe the algorithm(s) in the Scripting API would need to be adjusted then as well.

For now, I only implemented the protocol-specific `requestThingDescription` method for HTTP and CoAP, if the general design works for you more protocols could be added in follow-up PRs.