### PR TITLE
refactor: use a default contentType of application/json in Forms

### DIFF
--- a/packages/td-tools/src/thing-description.ts
+++ b/packages/td-tools/src/thing-description.ts
@@ -56,7 +56,7 @@ export type ThingInteraction = TDT.PropertyElement | TDT.ActionElement | TDT.Eve
 export class Form implements TDT.FormElementBase {
     op?: string | string[];
     href: TDT.AnyUri;
-    contentType?: string;
+    contentType: string;
     contentCoding?: string;
     subprotocol?: TDT.Subprotocol;
     security?: TDT.Security;
@@ -67,7 +67,7 @@ export class Form implements TDT.FormElementBase {
 
     constructor(href: string, contentType?: string) {
         this.href = href;
-        if (contentType != null) this.contentType = contentType;
+        this.contentType = contentType ?? "application/json";
     }
 }
 export interface ExpectedResponse {


### PR DESCRIPTION
As discussed in https://github.com/eclipse-thingweb/node-wot/pull/1175#discussion_r1409109652, this PR includes a proposal for making the `contentType` of the `Form` class non-nullable by defaulting to `application/json` when no Content-Type is passed to the constructor.

This change has the nice effect of getting rid of a lot of nullish coalescing which is currently required to arrive at the default value.