### PR TITLE
ci: add a total timeout of 30 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
                 os: [macos-latest, ubuntu-latest, windows-latest]
                 node-version: [18.x, 20.x]
 
+        timeout-minutes: 30
+
         steps:
             - name: Checkout
               uses: actions/checkout@v2


### PR DESCRIPTION
In the context of #1175, I noticed that the codecov step was somehow hanging for over 2 hours without causing the CI to fail. To address the issue, this PR proposes to add an additional "total" timeout value of 30 minutes for the whole job which should be enough to cover all runs that work as intended. 