### PR TITLE
Generic MQTT improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/@babel/runtime": {
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+            "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+            "dependencies": {
+                "regenerator-runtime": "^0.14.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -70,7 +81,7 @@
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
             "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "0.3.9"
             },
@@ -202,7 +213,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
             "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -211,13 +222,13 @@
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
             "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
             "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -4607,6 +4618,23 @@
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
             "dev": true
+        },
+        "node_modules/fast-unique-numbers": {
+            "version": "8.0.11",
+            "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.11.tgz",
+            "integrity": "sha512-FmTi6tqMymufGgYEGKWez0I3Ji9ykhHjVzhqhPFOQ3j+IM6Y4PMo+Q17BVCKmCjK6QiFJ+YVINaYScOyFrkzew==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.1.0"
+            }
+        },
+        "node_modules/fast-unique-numbers/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/fastfall": {
             "version": "1.5.1",
@@ -9245,6 +9273,11 @@
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
             "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
         },
+        "node_modules/regenerator-runtime": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
@@ -9840,7 +9873,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9849,7 +9882,7 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -10474,7 +10507,7 @@
             "version": "10.9.1",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
             "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -10517,7 +10550,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -11062,7 +11095,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.1.3",
@@ -11259,6 +11292,52 @@
             "dependencies": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
+        },
+        "node_modules/worker-timers": {
+            "version": "7.0.78",
+            "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.78.tgz",
+            "integrity": "sha512-jATkwi6OFe2XwfvoPYl3hr8k19/JgCiFerJ4ZWv5AbMIjsUnayC1C8Dxau/sevqhzCrU4IqXDFDTjNINGNuibQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.4",
+                "tslib": "^2.6.2",
+                "worker-timers-broker": "^6.0.98",
+                "worker-timers-worker": "^7.0.62"
+            }
+        },
+        "node_modules/worker-timers-broker": {
+            "version": "6.0.98",
+            "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.0.98.tgz",
+            "integrity": "sha512-Kq8dTnHBoBGXdMYHGYAtZ+gbxdsV085PF3QoxFZMDKvqPlyTuRFGQvc70k9fHeGOCFlUv6OUREvYF72aquBOFw==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.4",
+                "fast-unique-numbers": "^8.0.11",
+                "tslib": "^2.6.2",
+                "worker-timers-worker": "^7.0.62"
+            }
+        },
+        "node_modules/worker-timers-broker/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/worker-timers-worker": {
+            "version": "7.0.62",
+            "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.62.tgz",
+            "integrity": "sha512-WuVhWXWEqwcWD2Iy9tNQWQyfl984XF/hoblazHp4KOWiIN50B2PH0l61nBkJUndFhJ9qca0lEZ7SWSqdIMDWDQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.4",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/worker-timers-worker/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/worker-timers/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/workerpool": {
             "version": "6.2.0",
@@ -11542,8 +11621,206 @@
                 "@node-wot/core": "0.8.11",
                 "@node-wot/td-tools": "0.8.11",
                 "aedes": "^0.46.2",
-                "mqtt": "^4.2.8",
+                "mqtt": "^5.3.2",
                 "rxjs": "5.5.11"
+            }
+        },
+        "packages/binding-mqtt/node_modules/@types/readable-stream": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.9.tgz",
+            "integrity": "sha512-4cwuvrmNF96M4Nrx0Eep37RwPB1Mth+nCSezsGRv5+PsFyRvDdLd0pil6gVLcWD/bh69INNdwZ98dJwfHpLohA==",
+            "dependencies": {
+                "@types/node": "*",
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "packages/binding-mqtt/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "packages/binding-mqtt/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "packages/binding-mqtt/node_modules/commist": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+            "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw=="
+        },
+        "packages/binding-mqtt/node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "engines": [
+                "node >= 6.0"
+            ],
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "packages/binding-mqtt/node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "packages/binding-mqtt/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/binding-mqtt/node_modules/help-me": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+            "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+            "dependencies": {
+                "glob": "^8.0.0",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "packages/binding-mqtt/node_modules/lru-cache": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+            "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
+        "packages/binding-mqtt/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/binding-mqtt/node_modules/mqtt": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.3.2.tgz",
+            "integrity": "sha512-T7XP17IDxC+wGRtSUHtwQGomDYFYnW+vcFSPlsR2Xan7fB/KRR88WEzwqxFUvB/V73uLysmLr1kbuswN+E7Z9g==",
+            "dependencies": {
+                "@types/readable-stream": "^4.0.5",
+                "@types/ws": "^8.5.9",
+                "commist": "^3.2.0",
+                "concat-stream": "^2.0.0",
+                "debug": "^4.3.4",
+                "help-me": "^4.2.0",
+                "lru-cache": "^10.0.1",
+                "minimist": "^1.2.8",
+                "mqtt": "^5.2.0",
+                "mqtt-packet": "^9.0.0",
+                "number-allocator": "^1.0.14",
+                "readable-stream": "^4.4.2",
+                "reinterval": "^1.1.0",
+                "rfdc": "^1.3.0",
+                "split2": "^4.2.0",
+                "worker-timers": "^7.0.78",
+                "ws": "^8.14.2"
+            },
+            "bin": {
+                "mqtt": "build/bin/mqtt.js",
+                "mqtt_pub": "build/bin/pub.js",
+                "mqtt_sub": "build/bin/sub.js"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "packages/binding-mqtt/node_modules/mqtt-packet": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.0.tgz",
+            "integrity": "sha512-8v+HkX+fwbodsWAZIZTI074XIoxVBOmPeggQuDFCGg1SqNcC+uoRMWu7J6QlJPqIUIJXmjNYYHxBBLr1Y/Df4w==",
+            "dependencies": {
+                "bl": "^6.0.8",
+                "debug": "^4.3.4",
+                "process-nextick-args": "^2.0.1"
+            }
+        },
+        "packages/binding-mqtt/node_modules/mqtt/node_modules/readable-stream": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "packages/binding-mqtt/node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "packages/binding-mqtt/node_modules/ws": {
+            "version": "8.14.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "packages/binding-netconf": {

--- a/packages/binding-file/test/test2.txt
+++ b/packages/binding-file/test/test2.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet.

--- a/packages/binding-file/test/test2.txt
+++ b/packages/binding-file/test/test2.txt
@@ -1,1 +1,0 @@
-Lorem ipsum dolor sit amet.

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -17,7 +17,7 @@
         "@node-wot/core": "0.8.11",
         "@node-wot/td-tools": "0.8.11",
         "aedes": "^0.46.2",
-        "mqtt": "^4.2.8",
+        "mqtt": "^5.3.2",
         "rxjs": "5.5.11"
     },
     "scripts": {

--- a/packages/binding-mqtt/src/mqtt-client.ts
+++ b/packages/binding-mqtt/src/mqtt-client.ts
@@ -20,12 +20,12 @@
 import { ProtocolClient, Content, DefaultContent, createLoggers, ContentSerdes } from "@node-wot/core";
 import * as TD from "@node-wot/td-tools";
 import * as mqtt from "mqtt";
-import { MqttClientConfig, MqttForm, MqttQoS } from "./mqtt";
+import { MqttClientConfig, MqttForm } from "./mqtt";
 import * as url from "url";
 import { Subscription } from "rxjs/Subscription";
 import { Readable } from "stream";
-import { IClientPublishOptions } from "mqtt";
 import MQTTMessagePool from "./mqtt-message-pool";
+import { mapQoS } from "./util";
 
 const { debug, warn } = createLoggers("binding-mqtt", "mqtt-client");
 
@@ -130,7 +130,7 @@ export default class MqttClient implements ProtocolClient {
         const buffer = content === undefined ? Buffer.from("") : await content.toBuffer();
         await pool.publish(topic, buffer, {
             retain: form["mqv:retain"],
-            qos: this.mapQoS(form["mqv:qos"]),
+            qos: mapQoS(form["mqv:qos"]),
         });
     }
 
@@ -152,7 +152,7 @@ export default class MqttClient implements ProtocolClient {
         const buffer = content === undefined ? Buffer.from("") : await content.toBuffer();
         await pool.publish(topic, buffer, {
             retain: form["mqv:retain"],
-            qos: this.mapQoS(form["mqv:qos"]),
+            qos: mapQoS(form["mqv:qos"]),
         });
         // there will be no response
         return new DefaultContent(Readable.from([]));
@@ -205,22 +205,5 @@ export default class MqttClient implements ProtocolClient {
             }
         }
         return true;
-    }
-
-    private mapQoS(qos: MqttQoS | undefined): Required<IClientPublishOptions>["qos"] {
-        switch (qos) {
-            case "0":
-                return 0;
-            case "1":
-                return 1;
-            case "2":
-                return 2;
-            case undefined:
-                return 0;
-            default:
-                warn(`MqttClient received unsupported QoS level '${qos}'`);
-                warn(`MqttClient falling back to QoS level '0'`);
-                return 0;
-        }
     }
 }

--- a/packages/binding-mqtt/src/mqtt-message-pool.ts
+++ b/packages/binding-mqtt/src/mqtt-message-pool.ts
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { createLoggers } from "@node-wot/core";
+import { MqttClientConfig } from "./mqtt";
+import * as mqtt from "mqtt";
+
+const { debug, warn } = createLoggers("binding-mqtt", "mqtt-message-pool");
+
+export default class MQTTMessagePool {
+    client?: mqtt.MqttClient;
+    subscribers: Map<string, (topic: string, message: Buffer) => void> = new Map();
+    errors: Map<string, (error: Error) => void> = new Map();
+
+    public async connect(brokerURI: string, config: MqttClientConfig): Promise<void> {
+        if (this.client === undefined) {
+            this.client = await mqtt.connectAsync(brokerURI, config);
+            this.client.on("message", (receivedTopic: string, payload: Buffer) => {
+                debug(
+                    `Received MQTT message from ${brokerURI} (topic: ${receivedTopic}, data length: ${payload.length})`
+                );
+                this.subscribers.get(receivedTopic)?.(receivedTopic, payload);
+            });
+            // Connection errors should be deal by the connectAsync
+            // here we handle "runtime" parsing errors, but we can't do much
+            // therefore we broadcast the error to all subscribers
+            this.client.on("error", (error: Error) => {
+                warn(`MQTT client error: ${error.message}`);
+                this.errors.forEach((errorCallback) => {
+                    errorCallback(error);
+                });
+            });
+        }
+    }
+
+    public async subscribe(
+        filter: string | string[],
+        callback: (topic: string, message: Buffer) => void,
+        error: (error: Error) => void
+    ): Promise<void> {
+        if (this.client == null) {
+            throw new Error("MQTT client is not connected");
+        }
+
+        const filters = Array.isArray(filter) ? filter : [filter];
+        filters.forEach((f) => {
+            if (this.subscribers.has(f)) {
+                warn(`Already subscribed to ${f}; we are not supporting multiple subscribers to the same topic`);
+                warn(`The subscription will be ignored`);
+                return;
+            }
+
+            this.subscribers.set(f, callback);
+            this.errors.set(f, error);
+        });
+
+        await this.client.subscribeAsync(filters);
+    }
+
+    public async unsubscribe(filter: string | string[]): Promise<void> {
+        if (this.client == null) {
+            throw new Error("MQTT client is not connected");
+        }
+
+        const filters = Array.isArray(filter) ? filter : [filter];
+        filters.forEach((f) => {
+            this.subscribers.delete(f);
+            this.errors.delete(f);
+        });
+
+        await this.client.unsubscribeAsync(filters);
+    }
+
+    public async publish(topic: string, message: Buffer, options?: mqtt.IClientPublishOptions): Promise<void> {
+        if (this.client == null) {
+            throw new Error("MQTT client is not connected");
+        }
+
+        debug(`Publishing MQTT message to ${topic} (data length: ${message.length})`);
+        await this.client.publishAsync(topic, message, options);
+    }
+
+    public async end(): Promise<void> {
+        for (const filter of this.subscribers.keys()) {
+            this.unsubscribe(filter);
+        }
+        return this.client?.endAsync();
+    }
+}

--- a/packages/binding-mqtt/src/mqtt.ts
+++ b/packages/binding-mqtt/src/mqtt.ts
@@ -29,21 +29,16 @@ export * from "./mqtt-client-factory";
 export * from "./mqtts-client-factory";
 export * from "./mqtt-broker-server";
 
-/**
- * MQTT Quality of Service level.
- * QoS0: Fire-and-forget
- * QoS1: Deliver-at-least-once
- * QoS2: Deliver-exactly-once
- */
-export enum MqttQoS {
-    QoS0,
-    QoS1,
-    QoS2,
-}
-
+export type MqttQoS = "0" | "1" | "2";
 export class MqttForm extends Form {
-    public "mqtt:qos": MqttQoS = MqttQoS.QoS0;
-    public "mqtt:retain": boolean;
+    public "mqv:qos"?: MqttQoS = "0";
+    public "mqv:retain"?: boolean;
+
+    public "mqv:topic"?: string;
+
+    public "mqv:filter"?: string | string[];
+
+    public "mqv:controlPacket"?: "publish" | "subscribe" | "unsubscribe";
 }
 
 export interface MqttClientConfig {

--- a/packages/binding-mqtt/src/util.ts
+++ b/packages/binding-mqtt/src/util.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+import { createLoggers } from "@node-wot/core";
+import { MqttQoS } from "./mqtt";
+import { IClientPublishOptions } from "mqtt";
+
+const { debug, warn } = createLoggers("binding-mqtt", "mqtt-util");
+
+export function mapQoS(qos: MqttQoS | undefined): Required<IClientPublishOptions>["qos"] {
+    switch (qos) {
+        case "0":
+            return 0;
+        case "1":
+            return 1;
+        case "2":
+            return 2;
+        case undefined:
+            return 0;
+        default:
+            warn(`MqttClient received unsupported QoS level '${qos}'`);
+            warn(`MqttClient falling back to QoS level '0'`);
+            return 0;
+    }
+}

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
@@ -28,7 +28,7 @@ const info = createInfoLogger("binding-mqtt", "mqtt-client-subscribe-test.integr
 // should must be called to augment all variables
 should();
 
-describe("MQTT client implementation", () => {
+describe("MQTT client implementation - integration", () => {
     let servient: Servient;
     let brokerServer: MqttBrokerServer;
 

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.integration.ts
@@ -89,12 +89,12 @@ describe("MQTT client implementation - integration", () => {
                                 }
                             })
                             .then(() => {
-                                for (let i = 0; i < 4; i++) {
+                                for (let i = 0; i < 5; i++) {
                                     thing.emitEvent(eventName, i);
                                 }
                             })
                             .catch((e) => {
-                                expect(true).to.equal(false);
+                                done(e);
                             });
                     });
                 });
@@ -151,12 +151,12 @@ describe("MQTT client implementation - integration", () => {
                                 }
                             })
                             .then(() => {
-                                for (let i = 0; i < 4; i++) {
+                                for (let i = 0; i < 5; i++) {
                                     thing.emitEvent(eventName, i);
                                 }
                             })
                             .catch((e) => {
-                                expect(true).to.equal(false);
+                                done(e);
                             });
                     });
                 });

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.unit.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.unit.ts
@@ -31,7 +31,7 @@ chai.use(chaiAsPromised);
 // should must be called to augment all variables
 should();
 
-describe("MQTT client implementation", () => {
+describe("MQTT client implementation - unit", () => {
     let aedes: Aedes;
     let hostedBroker: net.Server;
     const property = "test1";
@@ -152,7 +152,7 @@ describe("MQTT client implementation", () => {
                 .then(() => done());
         }).timeout(10000);
 
-        it("should authenticate with basic auth", (done: Mocha.Done) => {
+        it("should authenticate with basic auth", async () => {
             const mqttClient = new MqttClient();
             mqttClient.setSecurity([{ scheme: "basic" }], { username: "user", password: "pass" });
 
@@ -162,12 +162,8 @@ describe("MQTT client implementation", () => {
                 "mqtt:retain": false,
             };
 
-            mqttClient
-                .subscribeResource(form, () => {
-                    /** */
-                })
-                .catch((err) => done(err))
-                .then(() => done());
+            await mqttClient.subscribeResource(form, () => {});
+            await mqttClient.stop();
         }).timeout(10000);
     });
 });

--- a/packages/binding-mqtt/test/mqtt-client-subscribe-test.unit.ts
+++ b/packages/binding-mqtt/test/mqtt-client-subscribe-test.unit.ts
@@ -19,7 +19,7 @@
 
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { MqttClient, MqttForm, MqttQoS } from "../src/mqtt";
+import { MqttClient, MqttForm } from "../src/mqtt";
 import { expect, should } from "chai";
 import { Aedes, Server } from "aedes";
 import * as net from "net";
@@ -61,8 +61,8 @@ describe("MQTT client implementation - unit", () => {
             const mqttClient = new MqttClient();
             const form: MqttForm = {
                 href: brokerUri + "/" + property,
-                "mqtt:qos": MqttQoS.QoS0,
-                "mqtt:retain": false,
+                "mqv:qos": "0",
+                "mqv:retain": false,
             };
 
             mqttClient
@@ -88,8 +88,8 @@ describe("MQTT client implementation - unit", () => {
             const mqttClient = new MqttClient();
             const form: MqttForm = {
                 href: brokerUri + "/" + property,
-                "mqtt:qos": MqttQoS.QoS0,
-                "mqtt:retain": false,
+                "mqv:qos": "0",
+                "mqv:retain": false,
             };
 
             mqttClient
@@ -139,8 +139,8 @@ describe("MQTT client implementation - unit", () => {
 
             const form: MqttForm = {
                 href: brokerUri + "/" + property,
-                "mqtt:qos": MqttQoS.QoS1,
-                "mqtt:retain": false,
+                "mqv:qos": "1",
+                "mqv:retain": false,
             };
 
             mqttClient
@@ -158,8 +158,8 @@ describe("MQTT client implementation - unit", () => {
 
             const form: MqttForm = {
                 href: brokerUri + "/" + property,
-                "mqtt:qos": MqttQoS.QoS1,
-                "mqtt:retain": false,
+                "mqv:qos": "1",
+                "mqv:retain": false,
             };
 
             await mqttClient.subscribeResource(form, () => {});


### PR DESCRIPTION
Given the latest problems that MQTT gave, I tried to revamp it a little bit the implementation in the hope that it would cause fewer problems and would be more maintainable. I took three steps:
- Upgrade the library to the latest MQTT implementation -> we get `async` methods -> cleaner implementation and cover corner cases where we forgot to use callbacks. 
- While I was there I updated the notation with the latest MQTT vocabulary
- I tried to tackle the issue raised in #955 by @ilovemilk . Now it should be fixed but give the current design of the Scripting API (and node-wot). the implementation is not that clean. I refer to the fact that we can't keep track of each listener by using functions as handlers but we use forms as identifiers. The end result is that if in your thing description you have two forms from different events that share a `mqv:filter` you can't subscribe to two events at the same time. I hope this is a corner case... if anybody else has suggestions on this let me know! 

Meanwhile I hope that this new changes also solves the problems in MacOS 