### PR TITLE
fix(coap-server): ignore incoming requests with an invalid source port

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -435,7 +435,9 @@ export default class CoapServer implements ProtocolServer {
     }
 
     private async handleRequest(req: IncomingMessage, res: OutgoingMessage) {
-        if (req.rsinfo.port === 0) {
+        const sourcePort = req.rsinfo.port;
+        const hasInvalidPortRange =  sourcePort < 1 || sourcePort > 65535;
+        if (hasInvalidPortRange) {
             // Ignore requests with an invalid source port
             // See https://github.com/eclipse-thingweb/node-wot/issues/1182
             return;

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -436,7 +436,7 @@ export default class CoapServer implements ProtocolServer {
 
     private async handleRequest(req: IncomingMessage, res: OutgoingMessage) {
         const sourcePort = req.rsinfo.port;
-        const hasInvalidPortRange =  sourcePort < 1 || sourcePort > 65535;
+        const hasInvalidPortRange = sourcePort < 1 || sourcePort > 65535;
         if (hasInvalidPortRange) {
             // Ignore requests with an invalid source port
             // See https://github.com/eclipse-thingweb/node-wot/issues/1182

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -435,6 +435,12 @@ export default class CoapServer implements ProtocolServer {
     }
 
     private async handleRequest(req: IncomingMessage, res: OutgoingMessage) {
+        if (req.rsinfo.port === 0) {
+            // Ignore requests with an invalid source port
+            // See https://github.com/eclipse-thingweb/node-wot/issues/1182
+            return;
+        }
+
         const origin = this.formatRequestOrigin(req);
 
         debug(


### PR DESCRIPTION
Resolves #1182.

This is more like a workaround for now to fix the crashes immediately but should be fixed at the library level eventually.