### PR TITLE
ci: re-run failed test steps with debug logging enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
                   timeout_minutes: 10
                   max_attempts: 2
                   command: npm run coverage:only
+                  # Rerun with debug logging enabled, but always fail the retry
                   new_command_on_retry: |
                       DEBUG=node-wot* npm run coverage:only
                       exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
                   command: npm run coverage:only
                   # Rerun with debug logging enabled, but always fail the retry
                   new_command_on_retry: |
-                      DEBUG=node-wot* npm run coverage:only
+                      DEBUG=node-wot* npm run test:only
                       exit 1
 
             - name: Upload to codecov.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
                   timeout_minutes: 10
                   max_attempts: 2
                   command: npm run coverage:only
-                  # Rerun with debug logging enabled, but always fail the retry
+                  # Rerun with debug logging enabled on error, but always fail the retry
                   new_command_on_retry: |
                       DEBUG=node-wot* npm run test:only
                       exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,7 @@ jobs:
                   new_command_on_retry: |
                       DEBUG=node-wot* npm run test:only
                       exit 1
+                  shell: bash
 
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,12 @@ jobs:
                   sudo echo "127.0.0.1" `hostname` | sudo tee -a /etc/hosts
 
             - name: Test with coverage report
-              run: npm run coverage:only
-              timeout-minutes: 10
+              uses: nick-fields/retry@v2
+              with:
+                  timeout_minutes: 10
+                  max_attempts: 2
+                  command: npm run coverage:only
+                  new_command_on_retry: DEBUG=node-wot* npm run coverage:only
 
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,9 @@ jobs:
                   timeout_minutes: 10
                   max_attempts: 2
                   command: npm run coverage:only
-                  new_command_on_retry: DEBUG=node-wot* npm run coverage:only
+                  new_command_on_retry: |
+                      DEBUG=node-wot* npm run coverage:only
+                      exit 1
 
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v2


### PR DESCRIPTION
This PR introduces a retry mechanism with enabled debug logging for failed CI testing steps as discussed in https://github.com/eclipse-thingweb/node-wot/pull/1184#issuecomment-1845510736.