### PR TITLE
refactor: avoid starting servient multiple times

### DIFF
--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -30,6 +30,9 @@ export default class Servient {
     private things: Map<string, ExposedThing> = new Map<string, ExposedThing>();
     private credentialStore: Map<string, Array<unknown>> = new Map<string, Array<unknown>>();
 
+    private started = false;
+    private shutdowned = false;
+
     /** add a new codec to support a mediatype; offered mediatypes are listed in TDs */
     public addMediaType(codec: ContentCodec, offered = false): void {
         ContentManager.addCodec(codec, offered);
@@ -210,18 +213,30 @@ export default class Servient {
 
     // will return WoT object
     public async start(): Promise<typeof WoT> {
+        if (this.started) {
+            throw Error("Servient started already");
+        }
         const serverStatus: Array<Promise<void>> = [];
         this.servers.forEach((server) => serverStatus.push(server.start(this)));
         this.clientFactories.forEach((clientFactory) => clientFactory.init());
 
         await Promise.all(serverStatus);
+        this.started = true;
         return new WoTImpl(this);
     }
 
     public async shutdown(): Promise<void> {
-        this.clientFactories.forEach((clientFactory) => clientFactory.destroy());
+        if (this.started) {
+            if (this.shutdowned) {
+                throw Error("Servient shutdowned already");
+            }
+            this.clientFactories.forEach((clientFactory) => clientFactory.destroy());
 
-        const promises = this.servers.map((server) => server.stop());
-        await Promise.all(promises);
+            const promises = this.servers.map((server) => server.stop());
+            await Promise.all(promises);
+            this.shutdowned = true;
+        } else {
+            debug(`Servient cannot be shutdown, wasn't even started`);
+        }
     }
 }

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -30,8 +30,8 @@ export default class Servient {
     private things: Map<string, ExposedThing> = new Map<string, ExposedThing>();
     private credentialStore: Map<string, Array<unknown>> = new Map<string, Array<unknown>>();
 
-    private started = false;
-    private shutdowned = false;
+    #started = false;
+    #shutdown = false;
 
     /** add a new codec to support a mediatype; offered mediatypes are listed in TDs */
     public addMediaType(codec: ContentCodec, offered = false): void {
@@ -213,7 +213,7 @@ export default class Servient {
 
     // will return WoT object
     public async start(): Promise<typeof WoT> {
-        if (this.started) {
+        if (this.#started) {
             throw Error("Servient started already");
         }
         const serverStatus: Array<Promise<void>> = [];
@@ -221,23 +221,23 @@ export default class Servient {
         this.clientFactories.forEach((clientFactory) => clientFactory.init());
 
         await Promise.all(serverStatus);
-        this.started = true;
+        this.#started = true;
         return new WoTImpl(this);
     }
 
     public async shutdown(): Promise<void> {
-        if (!this.started) {
-            debug("Servient cannot be shut down, wasn't even started");
+        if (!this.#started) {
+            debug("Servient cannot be shutdown, wasn't even started");
             return;
         }
-        if (this.shutdowned) {
-            throw Error("Servient shutdowned already");
+        if (this.#shutdown) {
+            throw Error("Servient shutdown already");
         }
 
         this.clientFactories.forEach((clientFactory) => clientFactory.destroy());
 
         const promises = this.servers.map((server) => server.stop());
         await Promise.all(promises);
-        this.shutdowned = true;
+        this.#shutdown = true;
     }
 }

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -226,17 +226,18 @@ export default class Servient {
     }
 
     public async shutdown(): Promise<void> {
-        if (this.started) {
-            if (this.shutdowned) {
-                throw Error("Servient shutdowned already");
-            }
-            this.clientFactories.forEach((clientFactory) => clientFactory.destroy());
-
-            const promises = this.servers.map((server) => server.stop());
-            await Promise.all(promises);
-            this.shutdowned = true;
-        } else {
-            debug(`Servient cannot be shutdown, wasn't even started`);
+        if (!this.started) {
+            debug("Servient cannot be shut down, wasn't even started");
+            return;
         }
+        if (this.shutdowned) {
+            throw Error("Servient shutdowned already");
+        }
+
+        this.clientFactories.forEach((clientFactory) => clientFactory.destroy());
+
+        const promises = this.servers.map((server) => server.stop());
+        await Promise.all(promises);
+        this.shutdowned = true;
     }
 }

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -213,7 +213,7 @@ export default class Servient {
 
     // will return WoT object
     public async start(): Promise<typeof WoT> {
-        if (this.#wotInstance != null) {
+        if (this.#wotInstance !== undefined) {
             debug("Servient started already -> nop -> returning previous WoT implementation");
             return this.#wotInstance;
         }

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -30,7 +30,7 @@ export default class Servient {
     private things: Map<string, ExposedThing> = new Map<string, ExposedThing>();
     private credentialStore: Map<string, Array<unknown>> = new Map<string, Array<unknown>>();
 
-    #startedWoT?: typeof WoT;
+    #wotInstance?: typeof WoT;
     #shutdown = false;
 
     /** add a new codec to support a mediatype; offered mediatypes are listed in TDs */
@@ -213,9 +213,9 @@ export default class Servient {
 
     // will return WoT object
     public async start(): Promise<typeof WoT> {
-        if (this.#startedWoT != null) {
+        if (this.#wotInstance != null) {
             debug("Servient started already -> nop -> returning previous WoT implementation");
-            return this.#startedWoT;
+            return this.#wotInstance;
         }
         if (this.#shutdown) {
             throw Error("Servient cannot be started (again) since it was already stopped");
@@ -226,11 +226,11 @@ export default class Servient {
         this.clientFactories.forEach((clientFactory) => clientFactory.init());
 
         await Promise.all(serverStatus);
-        return (this.#startedWoT = new WoTImpl(this));
+        return (this.#wotInstance = new WoTImpl(this));
     }
 
     public async shutdown(): Promise<void> {
-        if (this.#startedWoT === undefined) {
+        if (this.#wotInstance === undefined) {
             throw Error("Servient cannot be shutdown, wasn't even started");
         }
         if (this.#shutdown) {
@@ -243,6 +243,6 @@ export default class Servient {
         const promises = this.servers.map((server) => server.stop());
         await Promise.all(promises);
         this.#shutdown = true;
-        this.#startedWoT = undefined; // clean-up reference
+        this.#wotInstance = undefined; // clean-up reference
     }
 }


### PR DESCRIPTION
I think it should **not** be possible to start a servient multiple times. Hence I added a simple check.

Moreover, I _think_ a servient should be usable only once. Hence after a `shuthown` it is no longer usable.
Anyhow, I am open to other opinions whether we should allow for a re-`start` again?

fixes https://github.com/eclipse-thingweb/node-wot/issues/1193