### PR TITLE
ci: enable logging only when debug logging is enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,17 +47,14 @@ jobs:
               run: |
                   sudo echo "127.0.0.1" `hostname` | sudo tee -a /etc/hosts
 
+            - name: Configure debug logging
+              if: runner.debug == '1'
+              run: echo "DEBUG=node-wot*" >> $GITHUB_ENV
+              shell: bash
+
             - name: Test with coverage report
-              uses: nick-fields/retry@v2
-              with:
-                  timeout_minutes: 10
-                  max_attempts: 2
-                  command: npm run coverage:only
-                  # Rerun with debug logging enabled on error, but always fail the retry
-                  new_command_on_retry: |
-                      DEBUG=node-wot* npm run test:only
-                      exit 1
-                  shell: bash
+              timeout-minutes: 10
+              run: npm run coverage:only
 
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,12 @@ jobs:
               run: |
                   sudo echo "127.0.0.1" `hostname` | sudo tee -a /etc/hosts
 
+            # Enables the output of log messages from the Node.js debug module
+            # for workflow runs that are being retried with "debug logging"
+            # enabled.
+            #
+            # See https://github.com/eclipse-thingweb/node-wot/pull/1204 for
+            # more context regarding the rationale of this step.
             - name: Configure debug logging
               if: runner.debug == '1'
               run: echo "DEBUG=node-wot*" >> $GITHUB_ENV


### PR DESCRIPTION
In the menu for rerunning failed actions, I noticed that there is an option for "enabling debug logging" as can be seen in this screenshot:

<img width="661" alt="image" src="https://github.com/eclipse-thingweb/node-wot/assets/12641361/af6f9cf4-cbf3-4744-b4e3-af26eb3ab444">

Although we have introduced automatic reruns with debug logging in #1189, I got the impression that this change is not that well usable in practice, partly because it makes the logs for failed actions very long, thereby increasing the difficulty of finding the place where something went wrong.

This PR proposes using debug logging only when it is enabled via the GitHub actions UI that can be seen above, making the choice of seeing the verbose output a bit more deliberate. This change would also half the wait time for feedback on a failed test while getting rid of the external dependency introduced for retrying the tests automatically.