### PR TITLE
chore(binding-mqtt): remove unused debug import

### DIFF
--- a/packages/binding-mqtt/src/util.ts
+++ b/packages/binding-mqtt/src/util.ts
@@ -16,7 +16,7 @@ import { createLoggers } from "@node-wot/core";
 import { MqttQoS } from "./mqtt";
 import { IClientPublishOptions } from "mqtt";
 
-const { debug, warn } = createLoggers("binding-mqtt", "mqtt-util");
+const { warn } = createLoggers("binding-mqtt", "mqtt-util");
 
 export function mapQoS(qos: MqttQoS | undefined): Required<IClientPublishOptions>["qos"] {
     switch (qos) {


### PR DESCRIPTION
This is an extremely trivial PR that gets rid of the single warning eslint is currently reporting on the `master` branch.

Since the change is so simple, I will merge it right away.