### PR TITLE
chore: increase version numbers to 0.8.12 for next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,9 +61,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-            "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+            "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -114,9 +114,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-            "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -159,9 +159,9 @@
             "dev": true
         },
         "node_modules/@eslint/js": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-            "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+            "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -570,20 +570,20 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/x509": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.9.5.tgz",
-            "integrity": "sha512-6HBrlgoyH8sod0PTjQ8hzOL4/f5L94s5lwiL9Gr0P5HiSO8eeNgKoiB+s7VhDczE2aaloAgDXFjoQHVEcTg4mg==",
+            "version": "1.9.6",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.9.6.tgz",
+            "integrity": "sha512-BQhsxZa8SMJ8rwKJMb6VrdZk3XXE/5ab+JRr9psxHI9dw9gZrR3BsWrL3EgLoxrqOd2nP/mWVSSJGlA76aAbRw==",
             "dependencies": {
-                "@peculiar/asn1-cms": "^2.3.6",
-                "@peculiar/asn1-csr": "^2.3.6",
-                "@peculiar/asn1-ecc": "^2.3.6",
-                "@peculiar/asn1-pkcs9": "^2.3.6",
-                "@peculiar/asn1-rsa": "^2.3.6",
-                "@peculiar/asn1-schema": "^2.3.6",
-                "@peculiar/asn1-x509": "^2.3.6",
+                "@peculiar/asn1-cms": "^2.3.8",
+                "@peculiar/asn1-csr": "^2.3.8",
+                "@peculiar/asn1-ecc": "^2.3.8",
+                "@peculiar/asn1-pkcs9": "^2.3.8",
+                "@peculiar/asn1-rsa": "^2.3.8",
+                "@peculiar/asn1-schema": "^2.3.8",
+                "@peculiar/asn1-x509": "^2.3.8",
                 "pvtsutils": "^1.3.5",
-                "reflect-metadata": "^0.1.13",
-                "tslib": "^2.6.1",
+                "reflect-metadata": "^0.2.1",
+                "tslib": "^2.6.2",
                 "tsyringe": "^4.8.0"
             }
         },
@@ -685,9 +685,9 @@
             "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         },
         "node_modules/@serialport/bindings/node_modules/node-abi": {
-            "version": "3.51.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-            "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+            "version": "3.52.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+            "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -936,17 +936,17 @@
             "dev": true
         },
         "node_modules/@types/asn1": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha512-aMHAkHF/+RAZ5/OJsbmsXnatLHYgDwIAuVhwBybBn9aFbMr4xKyUMoCYgC5B1U3dbng+YKtsGPABlZtS9KwnMQ==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/async": {
-            "version": "3.2.23",
-            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.23.tgz",
-            "integrity": "sha512-/sDXs+HxCtt4/duO0AZFHs+ydQYHzd3qUybEFb+juRWQJNCFj3sYbqM2ABjWi8m7J93KXdJvIbDiARzqqIEESw=="
+            "version": "3.2.24",
+            "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.24.tgz",
+            "integrity": "sha512-8iHVLHsCCOBKjCF2KwFe0p9Z3rfM9mL+sSP8btyR5vTjJRAqpBYD28/ZLgXPf0pjG1VxOvtCV/BgXkQbpSe8Hw=="
         },
         "node_modules/@types/aws-iot-device-sdk": {
             "version": "2.2.8",
@@ -956,6 +956,121 @@
                 "@types/node": "*",
                 "@types/ws": "*",
                 "mqtt": "^4.2.8"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/commist": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+            "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+            "dependencies": {
+                "leven": "^2.1.0",
+                "minimist": "^1.1.0"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "engines": [
+                "node >= 6.0"
+            ],
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/help-me": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+            "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+            "dependencies": {
+                "glob": "^7.1.6",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/mqtt": {
+            "version": "4.3.8",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.8.tgz",
+            "integrity": "sha512-2xT75uYa0kiPEF/PE0VPdavmEkoBzMT/UL9moid0rAvlCtV48qBwxD62m7Ld/4j8tSkIO1E/iqRl/S72SEOhOw==",
+            "dependencies": {
+                "commist": "^1.0.0",
+                "concat-stream": "^2.0.0",
+                "debug": "^4.1.1",
+                "duplexify": "^4.1.1",
+                "help-me": "^3.0.0",
+                "inherits": "^2.0.3",
+                "lru-cache": "^6.0.0",
+                "minimist": "^1.2.5",
+                "mqtt-packet": "^6.8.0",
+                "number-allocator": "^1.0.9",
+                "pump": "^3.0.0",
+                "readable-stream": "^3.6.0",
+                "reinterval": "^1.1.0",
+                "rfdc": "^1.3.0",
+                "split2": "^3.1.0",
+                "ws": "^7.5.5",
+                "xtend": "^4.0.2"
+            },
+            "bin": {
+                "mqtt": "bin/mqtt.js",
+                "mqtt_pub": "bin/pub.js",
+                "mqtt_sub": "bin/sub.js"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/mqtt-packet": {
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+            "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+            "dependencies": {
+                "bl": "^4.0.2",
+                "debug": "^4.1.1",
+                "process-nextick-args": "^2.0.1"
+            }
+        },
+        "node_modules/@types/aws-iot-device-sdk/node_modules/split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "dependencies": {
+                "readable-stream": "^3.0.0"
             }
         },
         "node_modules/@types/basic-auth": {
@@ -978,9 +1093,9 @@
             }
         },
         "node_modules/@types/chai": {
-            "version": "4.3.10",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.10.tgz",
-            "integrity": "sha512-of+ICnbqjmFCiixUnqRulbylyXQrPqIGf/B3Jax1wIF3DvSheysQxAWvqHhZiW3IQrycvokcLcFQlveGp+vyNg==",
+            "version": "4.3.11",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
+            "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
             "dev": true
         },
         "node_modules/@types/chai-as-promised": {
@@ -1020,9 +1135,9 @@
             }
         },
         "node_modules/@types/dns-packet": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.3.tgz",
-            "integrity": "sha512-T7YsGU31kUqAeN5SzfJxapsTAVCXucSb4QsnB7wcbFBpdm7Y77r/5SBrUpdT3Ng22pgxJtLljtQtBvkP5BiSqg==",
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.4.tgz",
+            "integrity": "sha512-R0ORTvCCeujG+upKfV4JlvozKLdQWlpsducXGd1L6ezBChwpjSj9K84F+KoMDsZQ9RhOLTR1hnNrwJHWagY24g==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1086,9 +1201,9 @@
             "integrity": "sha512-sOA+eVnHU+FziThpMhuqs/tjFKe5gHVJKIS7g1BzhXP+e2FS8OvtzM0K3IzFxVksDOr98Gz5FJiZVxZ9uFoHhw=="
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.201",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
-            "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ=="
+            "version": "4.14.202",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
         },
         "node_modules/@types/lru-cache": {
             "version": "5.1.1",
@@ -1192,9 +1307,9 @@
             "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="
         },
         "node_modules/@types/semver": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-            "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg=="
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
         },
         "node_modules/@types/send": {
             "version": "0.17.4",
@@ -1236,9 +1351,9 @@
             }
         },
         "node_modules/@types/tough-cookie": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.11.tgz",
-            "integrity": "sha512-xtFyCxnfpItBS6wRt6M+be0PzNEP6J/CqTR0mHCf/OzIbbOOh6DQ1MjiyzDrzDctzgYSmRcHH3PBvTO2hYovLg=="
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
         },
         "node_modules/@types/uritemplate": {
             "version": "0.3.6",
@@ -1258,24 +1373,24 @@
             "dev": true
         },
         "node_modules/@types/ws": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
-            "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+            "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.10.0.tgz",
-            "integrity": "sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
+            "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.10.0",
-                "@typescript-eslint/type-utils": "6.10.0",
-                "@typescript-eslint/utils": "6.10.0",
-                "@typescript-eslint/visitor-keys": "6.10.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/type-utils": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -1301,15 +1416,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
-            "integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
+            "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.10.0",
-                "@typescript-eslint/types": "6.10.0",
-                "@typescript-eslint/typescript-estree": "6.10.0",
-                "@typescript-eslint/visitor-keys": "6.10.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1329,13 +1444,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
-            "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
+            "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.10.0",
-                "@typescript-eslint/visitor-keys": "6.10.0"
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1346,13 +1461,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.10.0.tgz",
-            "integrity": "sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
+            "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.10.0",
-                "@typescript-eslint/utils": "6.10.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -1373,9 +1488,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
-            "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
+            "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1386,13 +1501,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
-            "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
+            "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.10.0",
-                "@typescript-eslint/visitor-keys": "6.10.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1413,17 +1528,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
-            "integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
+            "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.10.0",
-                "@typescript-eslint/types": "6.10.0",
-                "@typescript-eslint/typescript-estree": "6.10.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -1438,12 +1553,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
-            "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
+            "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.10.0",
+                "@typescript-eslint/types": "6.15.0",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -1548,9 +1663,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
-            "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+            "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -2197,9 +2312,9 @@
             }
         },
         "node_modules/bl": {
-            "version": "6.0.8",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.8.tgz",
-            "integrity": "sha512-HCRq8z0+3vrGCjEKrbnK6blpDZ1xzhfZKCCuyvPC7upGcfXZSmaCumpVao/jC8o1hs/fOqJoCSPMabl+CQTPXg==",
+            "version": "6.0.9",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.9.tgz",
+            "integrity": "sha512-Vh+M9HMfeTST9rkkQ1utRnOeABNcBO3i0dJMFkenCv7JIp76XWx8uQOGpaXyXVyenrLDZsdAHXbf0Cz18Eb0fw==",
             "dependencies": {
                 "buffer": "^6.0.3",
                 "inherits": "^2.0.4",
@@ -2238,9 +2353,9 @@
             }
         },
         "node_modules/bl/node_modules/readable-stream": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
+            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
@@ -3013,9 +3128,9 @@
             }
         },
         "node_modules/coap/node_modules/readable-stream": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
+            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
@@ -3108,13 +3223,9 @@
             }
         },
         "node_modules/commist": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
-            "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
-            "dependencies": {
-                "leven": "^2.1.0",
-                "minimist": "^1.1.0"
-            }
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+            "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw=="
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -3881,15 +3992,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-            "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+            "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.3",
-                "@eslint/js": "8.53.0",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.56.0",
                 "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -3935,10 +4046,23 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint-compat-utils": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz",
+            "integrity": "sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
         "node_modules/eslint-config-prettier": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-            "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+            "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -4042,14 +4166,15 @@
             }
         },
         "node_modules/eslint-plugin-es-x": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.3.0.tgz",
-            "integrity": "sha512-W9zIs+k00I/I13+Bdkl/zG1MEO07G97XjUSQuH117w620SJ6bHtLUmoMvkGA2oYnI/gNdr+G7BONLyYnFaLLEQ==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
+            "integrity": "sha512-ODswlDSO0HJDzXU0XvgZ3lF3lS3XAZEossh15Q2UHjwrJggWeBoKqqEsLTZLXl+dh5eOAozG0zRcYtuE35oTuQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.1.2",
-                "@eslint-community/regexpp": "^4.6.0"
+                "@eslint-community/regexpp": "^4.6.0",
+                "eslint-compat-utils": "^0.1.2"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -4062,9 +4187,9 @@
             }
         },
         "node_modules/eslint-plugin-import": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-            "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
+            "version": "2.29.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+            "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
             "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.7",
@@ -4083,7 +4208,7 @@
                 "object.groupby": "^1.0.1",
                 "object.values": "^1.1.7",
                 "semver": "^6.3.1",
-                "tsconfig-paths": "^3.14.2"
+                "tsconfig-paths": "^3.15.0"
             },
             "engines": {
                 "node": ">=4"
@@ -4123,15 +4248,15 @@
             }
         },
         "node_modules/eslint-plugin-n": {
-            "version": "16.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
-            "integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.5.0.tgz",
+            "integrity": "sha512-Hw02Bj1QrZIlKyj471Tb1jSReTl4ghIMHGuBGiMVmw+s0jOPbI4CBuYpGbZr+tdQ+VAvSK6FDSta3J4ib/SKHQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "builtins": "^5.0.1",
-                "eslint-plugin-es-x": "^7.1.0",
+                "eslint-plugin-es-x": "^7.5.0",
                 "get-tsconfig": "^4.7.0",
                 "ignore": "^5.2.4",
                 "is-builtin-module": "^3.2.1",
@@ -4620,11 +4745,11 @@
             "dev": true
         },
         "node_modules/fast-unique-numbers": {
-            "version": "8.0.11",
-            "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.11.tgz",
-            "integrity": "sha512-FmTi6tqMymufGgYEGKWez0I3Ji9ykhHjVzhqhPFOQ3j+IM6Y4PMo+Q17BVCKmCjK6QiFJ+YVINaYScOyFrkzew==",
+            "version": "8.0.12",
+            "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.12.tgz",
+            "integrity": "sha512-Z4AJueNDnuC/sLxeQqrHP4zgqcBIeQQLbQ0hEx1a7m6Wf7ERrdAyR7CkGfoEFWm9Qla7dpLt0eWPyiO18gqj0A==",
             "dependencies": {
-                "@babel/runtime": "^7.23.4",
+                "@babel/runtime": "^7.23.5",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4657,9 +4782,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+            "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -5158,9 +5283,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.23.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-            "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -5403,12 +5528,49 @@
             }
         },
         "node_modules/help-me": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
-            "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+            "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
             "dependencies": {
-                "glob": "^7.1.6",
+                "glob": "^8.0.0",
                 "readable-stream": "^3.6.0"
+            }
+        },
+        "node_modules/help-me/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/help-me/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/help-me/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/hexy": {
@@ -5551,9 +5713,9 @@
             ]
         },
         "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+            "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -5654,14 +5816,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/ip-regex": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-            "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/ipaddr.js": {
@@ -6180,9 +6334,9 @@
             }
         },
         "node_modules/jsrsasign": {
-            "version": "10.8.6",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
-            "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw==",
+            "version": "10.9.0",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.9.0.tgz",
+            "integrity": "sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ==",
             "funding": {
                 "url": "https://github.com/kjur/jsrsasign#donations"
             }
@@ -6738,35 +6892,35 @@
             }
         },
         "node_modules/mqtt": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
-            "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.3.3.tgz",
+            "integrity": "sha512-iy/9I81xnmYxENKL91hdiJ1LOkNYygCE0xCUtLeEo3BjQHraOky5gB/X3aPnvZ2fqlm1C0BhLmVcL6NRJ/U4tA==",
             "dependencies": {
-                "commist": "^1.0.0",
+                "@types/readable-stream": "^4.0.5",
+                "@types/ws": "^8.5.9",
+                "commist": "^3.2.0",
                 "concat-stream": "^2.0.0",
-                "debug": "^4.1.1",
-                "duplexify": "^4.1.1",
-                "help-me": "^3.0.0",
-                "inherits": "^2.0.3",
-                "lru-cache": "^6.0.0",
-                "minimist": "^1.2.5",
-                "mqtt-packet": "^6.8.0",
-                "number-allocator": "^1.0.9",
-                "pump": "^3.0.0",
-                "readable-stream": "^3.6.0",
+                "debug": "^4.3.4",
+                "help-me": "^4.2.0",
+                "lru-cache": "^10.0.1",
+                "minimist": "^1.2.8",
+                "mqtt": "^5.2.0",
+                "mqtt-packet": "^9.0.0",
+                "number-allocator": "^1.0.14",
+                "readable-stream": "^4.4.2",
                 "reinterval": "^1.1.0",
                 "rfdc": "^1.3.0",
-                "split2": "^3.1.0",
-                "ws": "^7.5.5",
-                "xtend": "^4.0.2"
+                "split2": "^4.2.0",
+                "worker-timers": "^7.0.78",
+                "ws": "^8.14.2"
             },
             "bin": {
-                "mqtt": "bin/mqtt.js",
-                "mqtt_pub": "bin/pub.js",
-                "mqtt_sub": "bin/sub.js"
+                "mqtt": "build/bin/mqtt.js",
+                "mqtt_pub": "build/bin/pub.js",
+                "mqtt_sub": "build/bin/sub.js"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/mqtt-packet": {
@@ -6812,20 +6966,19 @@
                 "ieee754": "^1.1.13"
             }
         },
-        "node_modules/mqtt/node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+        "node_modules/mqtt/node_modules/@types/readable-stream": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.10.tgz",
+            "integrity": "sha512-AbUKBjcC8SHmImNi4yK2bbjogQlkFSg7shZCcicxPQapniOlajG8GCc39lvXzCWX4lLRRs7DM3VAeSlqmEVZUA==",
             "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
+                "@types/node": "*",
+                "safe-buffer": "~5.1.1"
             }
         },
         "node_modules/mqtt/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "funding": [
                 {
                     "type": "github",
@@ -6842,7 +6995,7 @@
             ],
             "dependencies": {
                 "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
+                "ieee754": "^1.2.1"
             }
         },
         "node_modules/mqtt/node_modules/concat-stream": {
@@ -6859,14 +7012,78 @@
                 "typedarray": "^0.0.6"
             }
         },
-        "node_modules/mqtt/node_modules/mqtt-packet": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
-            "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+        "node_modules/mqtt/node_modules/concat-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dependencies": {
-                "bl": "^4.0.2",
-                "debug": "^4.1.1",
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/mqtt/node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/mqtt/node_modules/lru-cache": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+            "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
+        "node_modules/mqtt/node_modules/mqtt-packet": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.0.tgz",
+            "integrity": "sha512-8v+HkX+fwbodsWAZIZTI074XIoxVBOmPeggQuDFCGg1SqNcC+uoRMWu7J6QlJPqIUIJXmjNYYHxBBLr1Y/Df4w==",
+            "dependencies": {
+                "bl": "^6.0.8",
+                "debug": "^4.3.4",
                 "process-nextick-args": "^2.0.1"
+            }
+        },
+        "node_modules/mqtt/node_modules/readable-stream": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
+            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/mqtt/node_modules/ws": {
+            "version": "8.15.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
+            "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/mri": {
@@ -8327,12 +8544,12 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
                 "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             },
@@ -8664,18 +8881,21 @@
             }
         },
         "node_modules/popsicle": {
-            "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-12.1.0.tgz",
-            "integrity": "sha512-muNC/cIrWhfR6HqqhHazkxjob3eyECBe8uZYSQ/N5vixNAgssacVleerXnE8Are5fspR0a+d2qWaBR1g7RYlmw==",
+            "version": "12.1.2",
+            "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-12.1.2.tgz",
+            "integrity": "sha512-xE2vEUa15TiHvFhGmKTtdKk9aSLL5CHX8Vw5kHfVM3R0YHiaTon6Ybsamw0XYqMR+Ng2RijX88iYUKPBMpLBww==",
             "dependencies": {
                 "popsicle-content-encoding": "^1.0.0",
-                "popsicle-cookie-jar": "^1.0.0",
+                "popsicle-cookie-jar": "^1.0.1",
                 "popsicle-redirects": "^1.1.0",
-                "popsicle-transport-http": "^1.0.8",
+                "popsicle-transport-http": "^1.1.0",
                 "popsicle-transport-xhr": "^2.0.0",
                 "popsicle-user-agent": "^1.0.0",
                 "servie": "^4.3.3",
                 "throwback": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/popsicle-content-encoding": {
@@ -8687,12 +8907,15 @@
             }
         },
         "node_modules/popsicle-cookie-jar": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/popsicle-cookie-jar/-/popsicle-cookie-jar-1.0.0.tgz",
-            "integrity": "sha512-vrlOGvNVELko0+J8NpGC5lHWDGrk8LQJq9nwAMIVEVBfN1Lib3BLxAaLRGDTuUnvl45j5N9dT2H85PULz6IjjQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/popsicle-cookie-jar/-/popsicle-cookie-jar-1.0.1.tgz",
+            "integrity": "sha512-QVIZhADP8nDbXIQW6wq8GU9IOSE8INUACO/9KD9TFKQ7qq8r/y3qUDz59xIi6p6TH19lCJJyBAPSXP1liIoySw==",
             "dependencies": {
-                "@types/tough-cookie": "^2.3.5",
-                "tough-cookie": "^3.0.1"
+                "@types/tough-cookie": "^4.0.2",
+                "tough-cookie": "^4.1.3"
+            },
+            "engines": {
+                "node": ">=8"
             },
             "peerDependencies": {
                 "servie": "^4.0.0"
@@ -9209,9 +9432,9 @@
         },
         "node_modules/readable-stream4": {
             "name": "readable-stream",
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
+            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
             "dev": true,
             "dependencies": {
                 "abort-controller": "^3.0.0",
@@ -9269,14 +9492,14 @@
             }
         },
         "node_modules/reflect-metadata": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
+            "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
         },
         "node_modules/regenerator-runtime": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.1",
@@ -9897,11 +10120,11 @@
             }
         },
         "node_modules/split2": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-            "dependencies": {
-                "readable-stream": "^3.0.0"
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "engines": {
+                "node": ">= 10.x"
             }
         },
         "node_modules/sprintf-js": {
@@ -10469,13 +10692,14 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dependencies": {
-                "ip-regex": "^2.1.0",
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
             },
             "engines": {
                 "node": ">=6"
@@ -10556,9 +10780,9 @@
             }
         },
         "node_modules/tsconfig-paths": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-            "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+            "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "dev": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
@@ -10940,9 +11164,9 @@
             }
         },
         "node_modules/ufo": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.1.tgz",
-            "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+            "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
             "dev": true
         },
         "node_modules/umd": {
@@ -10983,6 +11207,14 @@
             },
             "bin": {
                 "undeclared-identifiers": "bin.js"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/unpipe": {
@@ -11098,9 +11330,9 @@
             "devOptional": true
         },
         "node_modules/v8-to-istanbul": {
-            "version": "9.1.3",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-            "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
@@ -11294,25 +11526,25 @@
             }
         },
         "node_modules/worker-timers": {
-            "version": "7.0.78",
-            "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.78.tgz",
-            "integrity": "sha512-jATkwi6OFe2XwfvoPYl3hr8k19/JgCiFerJ4ZWv5AbMIjsUnayC1C8Dxau/sevqhzCrU4IqXDFDTjNINGNuibQ==",
+            "version": "7.0.80",
+            "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.80.tgz",
+            "integrity": "sha512-bYSAPNVR0Nrm7hTM3hQOxM3x+D9dXFG6kZ0BBqFyRu0BUGC5+DLLK5Sx281hCaNzOGMNcUMEaoeErx3Yuf7XIw==",
             "dependencies": {
-                "@babel/runtime": "^7.23.4",
+                "@babel/runtime": "^7.23.6",
                 "tslib": "^2.6.2",
-                "worker-timers-broker": "^6.0.98",
-                "worker-timers-worker": "^7.0.62"
+                "worker-timers-broker": "^6.0.100",
+                "worker-timers-worker": "^7.0.64"
             }
         },
         "node_modules/worker-timers-broker": {
-            "version": "6.0.98",
-            "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.0.98.tgz",
-            "integrity": "sha512-Kq8dTnHBoBGXdMYHGYAtZ+gbxdsV085PF3QoxFZMDKvqPlyTuRFGQvc70k9fHeGOCFlUv6OUREvYF72aquBOFw==",
+            "version": "6.0.100",
+            "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.0.100.tgz",
+            "integrity": "sha512-sXF1NpuT+FlJvONSbdZ6wNB15oNGg/P6PvCZDMHWmI6s7bHEb0zQ7cTnk9k+96/3pd8SpbXFuM0/HcHVc2alDQ==",
             "dependencies": {
-                "@babel/runtime": "^7.23.4",
-                "fast-unique-numbers": "^8.0.11",
+                "@babel/runtime": "^7.23.6",
+                "fast-unique-numbers": "^8.0.12",
                 "tslib": "^2.6.2",
-                "worker-timers-worker": "^7.0.62"
+                "worker-timers-worker": "^7.0.64"
             }
         },
         "node_modules/worker-timers-broker/node_modules/tslib": {
@@ -11321,11 +11553,11 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/worker-timers-worker": {
-            "version": "7.0.62",
-            "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.62.tgz",
-            "integrity": "sha512-WuVhWXWEqwcWD2Iy9tNQWQyfl984XF/hoblazHp4KOWiIN50B2PH0l61nBkJUndFhJ9qca0lEZ7SWSqdIMDWDQ==",
+            "version": "7.0.64",
+            "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.64.tgz",
+            "integrity": "sha512-bzBO7rVibSYFKu5NBYfjKBKHujaA/AJzJTuEEqaOGfzcTdJv15raDuGhtDoMjcNPvt3IylfLph6AK92kuifnXA==",
             "dependencies": {
-                "@babel/runtime": "^7.23.4",
+                "@babel/runtime": "^7.23.6",
                 "tslib": "^2.6.2"
             }
         },
@@ -11536,11 +11768,11 @@
         },
         "packages/binding-coap": {
             "name": "@node-wot/binding-coap",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "@types/node": "16.18.35",
                 "coap": "^1.3.0",
                 "multicast-dns": "^7.2.5",
@@ -11552,22 +11784,22 @@
         },
         "packages/binding-file": {
             "name": "@node-wot/binding-file",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11"
+                "@node-wot/core": "0.8.12"
             },
             "devDependencies": {
-                "@node-wot/td-tools": "0.8.11"
+                "@node-wot/td-tools": "0.8.12"
             }
         },
         "packages/binding-http": {
             "name": "@node-wot/binding-http",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "@types/eventsource": "1.1.10",
                 "accept-language-parser": "1.5.0",
                 "basic-auth": "2.0.1",
@@ -11592,22 +11824,22 @@
         },
         "packages/binding-mbus": {
             "name": "@node-wot/binding-mbus",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "node-mbus": "^2.1.0",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
             }
         },
         "packages/binding-modbus": {
             "name": "@node-wot/binding-modbus",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "modbus-serial": "8.0.3",
                 "rxjs": "5.5.11",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
@@ -11615,221 +11847,23 @@
         },
         "packages/binding-mqtt": {
             "name": "@node-wot/binding-mqtt",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "aedes": "^0.46.2",
                 "mqtt": "^5.3.2",
                 "rxjs": "5.5.11"
             }
         },
-        "packages/binding-mqtt/node_modules/@types/readable-stream": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.9.tgz",
-            "integrity": "sha512-4cwuvrmNF96M4Nrx0Eep37RwPB1Mth+nCSezsGRv5+PsFyRvDdLd0pil6gVLcWD/bh69INNdwZ98dJwfHpLohA==",
-            "dependencies": {
-                "@types/node": "*",
-                "safe-buffer": "~5.1.1"
-            }
-        },
-        "packages/binding-mqtt/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "packages/binding-mqtt/node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "packages/binding-mqtt/node_modules/commist": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
-            "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw=="
-        },
-        "packages/binding-mqtt/node_modules/concat-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-            "engines": [
-                "node >= 6.0"
-            ],
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.0.2",
-                "typedarray": "^0.0.6"
-            }
-        },
-        "packages/binding-mqtt/node_modules/events": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "engines": {
-                "node": ">=0.8.x"
-            }
-        },
-        "packages/binding-mqtt/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/binding-mqtt/node_modules/help-me": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
-            "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
-            "dependencies": {
-                "glob": "^8.0.0",
-                "readable-stream": "^3.6.0"
-            }
-        },
-        "packages/binding-mqtt/node_modules/lru-cache": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-            "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-            "engines": {
-                "node": "14 || >=16.14"
-            }
-        },
-        "packages/binding-mqtt/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "packages/binding-mqtt/node_modules/mqtt": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.3.2.tgz",
-            "integrity": "sha512-T7XP17IDxC+wGRtSUHtwQGomDYFYnW+vcFSPlsR2Xan7fB/KRR88WEzwqxFUvB/V73uLysmLr1kbuswN+E7Z9g==",
-            "dependencies": {
-                "@types/readable-stream": "^4.0.5",
-                "@types/ws": "^8.5.9",
-                "commist": "^3.2.0",
-                "concat-stream": "^2.0.0",
-                "debug": "^4.3.4",
-                "help-me": "^4.2.0",
-                "lru-cache": "^10.0.1",
-                "minimist": "^1.2.8",
-                "mqtt": "^5.2.0",
-                "mqtt-packet": "^9.0.0",
-                "number-allocator": "^1.0.14",
-                "readable-stream": "^4.4.2",
-                "reinterval": "^1.1.0",
-                "rfdc": "^1.3.0",
-                "split2": "^4.2.0",
-                "worker-timers": "^7.0.78",
-                "ws": "^8.14.2"
-            },
-            "bin": {
-                "mqtt": "build/bin/mqtt.js",
-                "mqtt_pub": "build/bin/pub.js",
-                "mqtt_sub": "build/bin/sub.js"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "packages/binding-mqtt/node_modules/mqtt-packet": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.0.tgz",
-            "integrity": "sha512-8v+HkX+fwbodsWAZIZTI074XIoxVBOmPeggQuDFCGg1SqNcC+uoRMWu7J6QlJPqIUIJXmjNYYHxBBLr1Y/Df4w==",
-            "dependencies": {
-                "bl": "^6.0.8",
-                "debug": "^4.3.4",
-                "process-nextick-args": "^2.0.1"
-            }
-        },
-        "packages/binding-mqtt/node_modules/mqtt/node_modules/readable-stream": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-            "dependencies": {
-                "abort-controller": "^3.0.0",
-                "buffer": "^6.0.3",
-                "events": "^3.3.0",
-                "process": "^0.11.10",
-                "string_decoder": "^1.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "packages/binding-mqtt/node_modules/split2": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-            "engines": {
-                "node": ">= 10.x"
-            }
-        },
-        "packages/binding-mqtt/node_modules/ws": {
-            "version": "8.14.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "packages/binding-netconf": {
             "name": "@node-wot/binding-netconf",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "@types/node-netconf": "npm:@types/netconf@^2.0.0",
                 "@types/url-parse": "^1.4.3",
                 "case-1.5.3": "npm:case@^1.5.3",
@@ -11839,11 +11873,11 @@
         },
         "packages/binding-opcua": {
             "name": "@node-wot/binding-opcua",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "ajv": "^8.11.0",
                 "ajv-formats": "^2.1.1",
                 "node-opcua": "2.113.0",
@@ -11877,19 +11911,19 @@
         },
         "packages/binding-websockets": {
             "name": "@node-wot/binding-websockets",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-http": "0.8.11",
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/binding-http": "0.8.12",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "slugify": "^1.4.5",
                 "ws": "^7.5.4"
             }
         },
         "packages/browser-bundle": {
             "name": "@node-wot/browser-bundle",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "events": "^2.1.0",
@@ -11897,26 +11931,26 @@
                 "resolve": "^1.1.7"
             },
             "devDependencies": {
-                "@node-wot/binding-http": "0.8.11",
-                "@node-wot/binding-websockets": "0.8.11",
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/binding-http": "0.8.12",
+                "@node-wot/binding-websockets": "0.8.12",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "browserify": "^17.0.0",
                 "readable-stream4": "npm:readable-stream@^4.0.0"
             }
         },
         "packages/cli": {
             "name": "@node-wot/cli",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.11",
-                "@node-wot/binding-file": "0.8.11",
-                "@node-wot/binding-http": "0.8.11",
-                "@node-wot/binding-mqtt": "0.8.11",
-                "@node-wot/binding-websockets": "0.8.11",
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/binding-coap": "0.8.12",
+                "@node-wot/binding-file": "0.8.12",
+                "@node-wot/binding-http": "0.8.12",
+                "@node-wot/binding-mqtt": "0.8.12",
+                "@node-wot/binding-websockets": "0.8.12",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "@types/lodash": "^4.14.199",
                 "ajv": "^8.11.0",
                 "commander": "^9.1.0",
@@ -11933,10 +11967,10 @@
         },
         "packages/core": {
             "name": "@node-wot/core",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/td-tools": "0.8.12",
                 "@petamoriken/float16": "^3.1.1",
                 "ajv": "^8.11.0",
                 "cbor": "^8.1.0",
@@ -11953,22 +11987,22 @@
         },
         "packages/examples": {
             "name": "@node-wot/examples",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.11",
-                "@node-wot/binding-file": "0.8.11",
-                "@node-wot/binding-http": "0.8.11",
-                "@node-wot/binding-mqtt": "0.8.11",
-                "@node-wot/binding-opcua": "0.8.11",
-                "@node-wot/core": "0.8.11",
-                "@node-wot/td-tools": "0.8.11",
+                "@node-wot/binding-coap": "0.8.12",
+                "@node-wot/binding-file": "0.8.12",
+                "@node-wot/binding-http": "0.8.12",
+                "@node-wot/binding-mqtt": "0.8.12",
+                "@node-wot/binding-opcua": "0.8.12",
+                "@node-wot/core": "0.8.12",
+                "@node-wot/td-tools": "0.8.12",
                 "rxjs": "5.5.11"
             }
         },
         "packages/td-tools": {
             "name": "@node-wot/td-tools",
-            "version": "0.8.11",
+            "version": "0.8.12",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "ajv": "^8.11.0",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-coap",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "CoAP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/coap.js",
     "types": "dist/coap.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "@types/node": "16.18.35",
         "coap": "^1.3.0",
         "multicast-dns": "^7.2.5",

--- a/packages/binding-file/package.json
+++ b/packages/binding-file/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-file",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "File client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,10 +14,10 @@
     "main": "dist/file.js",
     "types": "dist/file.d.ts",
     "devDependencies": {
-        "@node-wot/td-tools": "0.8.11"
+        "@node-wot/td-tools": "0.8.12"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.11"
+        "@node-wot/core": "0.8.12"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-http",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "HTTP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -28,8 +28,8 @@
         "timekeeper": "^2.2.0"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "@types/eventsource": "1.1.10",
         "accept-language-parser": "1.5.0",
         "basic-auth": "2.0.1",

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mbus",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "M-Bus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/mbus.js",
     "types": "dist/mbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "node-mbus": "^2.1.0",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     },

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-modbus",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "Modbus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "contributors": [
@@ -17,8 +17,8 @@
     "main": "dist/modbus.js",
     "types": "dist/modbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "modbus-serial": "8.0.3",
         "rxjs": "5.5.11",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mqtt",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "MQTT binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/mqtt.js",
     "types": "dist/mqtt.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "aedes": "^0.46.2",
         "mqtt": "^5.3.2",
         "rxjs": "5.5.11"

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-netconf",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "NetConf client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/netconf.js",
     "types": "dist/netconf.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "@types/node-netconf": "npm:@types/netconf@^2.0.0",
         "@types/url-parse": "^1.4.3",
         "case-1.5.3": "npm:case@^1.5.3",

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-opcua",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "opcua client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -18,8 +18,8 @@
         "should": "^13.2.3"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "node-opcua": "2.113.0",

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-websockets",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "WebSockets client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -15,9 +15,9 @@
     "types": "dist/ws.d.ts",
     "browser": "dist/ws-browser.js",
     "dependencies": {
-        "@node-wot/binding-http": "0.8.11",
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/binding-http": "0.8.12",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "slugify": "^1.4.5",
         "ws": "^7.5.4"
     },

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/browser-bundle",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "A node-wot bundle that can run in a web browser",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -13,10 +13,10 @@
     ],
     "main": "dist/wot-bundle.min.js",
     "devDependencies": {
-        "@node-wot/binding-http": "0.8.11",
-        "@node-wot/binding-websockets": "0.8.11",
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/binding-http": "0.8.12",
+        "@node-wot/binding-websockets": "0.8.12",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "browserify": "^17.0.0",
         "readable-stream4": "npm:readable-stream@^4.0.0"
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/cli",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "servient command line interface",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -20,13 +20,13 @@
         "ts-node": "10.9.1"
     },
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.11",
-        "@node-wot/binding-file": "0.8.11",
-        "@node-wot/binding-http": "0.8.11",
-        "@node-wot/binding-mqtt": "0.8.11",
-        "@node-wot/binding-websockets": "0.8.11",
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/binding-coap": "0.8.12",
+        "@node-wot/binding-file": "0.8.12",
+        "@node-wot/binding-http": "0.8.12",
+        "@node-wot/binding-mqtt": "0.8.12",
+        "@node-wot/binding-websockets": "0.8.12",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "@types/lodash": "^4.14.199",
         "ajv": "^8.11.0",
         "commander": "^9.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/core",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "W3C Web of Things (WoT) Servient framework",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -20,7 +20,7 @@
         "@types/uuid": "^8.3.1"
     },
     "dependencies": {
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/td-tools": "0.8.12",
         "@petamoriken/float16": "^3.1.1",
         "ajv": "^8.11.0",
         "cbor": "^8.1.0",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,19 +1,19 @@
 {
     "name": "@node-wot/examples",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "private": true,
     "description": "Examples for node-wot (not published)",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
     "repository": "https://github.com/eclipse-thingweb/node-wot/tree/master/packages/examples",
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.11",
-        "@node-wot/binding-file": "0.8.11",
-        "@node-wot/binding-http": "0.8.11",
-        "@node-wot/binding-mqtt": "0.8.11",
-        "@node-wot/binding-opcua": "0.8.11",
-        "@node-wot/core": "0.8.11",
-        "@node-wot/td-tools": "0.8.11",
+        "@node-wot/binding-coap": "0.8.12",
+        "@node-wot/binding-file": "0.8.12",
+        "@node-wot/binding-http": "0.8.12",
+        "@node-wot/binding-mqtt": "0.8.12",
+        "@node-wot/binding-opcua": "0.8.12",
+        "@node-wot/core": "0.8.12",
+        "@node-wot/td-tools": "0.8.12",
         "rxjs": "5.5.11"
     },
     "scripts": {

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/td-tools",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "description": "W3C Web of Things (WoT) Thing Description parser, serializer, and other tools",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",


### PR DESCRIPTION
FYI: Every time we update the node-wot package versions we also newly create `package-lock.json` to update dependencies.
Hence one can see many changes for `package-lock.json` ...