### PR TITLE
chore: add `guard-for-in` eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "unused-imports/no-unused-imports": "error",
         "@typescript-eslint/strict-boolean-expressions": "error",
+        "guard-for-in": "error",
         "unused-imports/no-unused-vars": [
             "warn",
             {

--- a/packages/binding-coap/src/mdns-introducer.ts
+++ b/packages/binding-coap/src/mdns-introducer.ts
@@ -73,8 +73,8 @@ export class MdnsIntroducer {
     private determineTarget(): string {
         const interfaces = networkInterfaces();
 
-        for (const iface in interfaces) {
-            for (const entry of interfaces[iface] ?? []) {
+        for (const iface of Object.values(interfaces ?? {})) {
+            for (const entry of iface ?? []) {
                 if (entry.internal === false) {
                     if (entry.family === this.ipAddressFamily) {
                         return entry.address;

--- a/packages/binding-http/src/http-browser.ts
+++ b/packages/binding-http/src/http-browser.ts
@@ -54,8 +54,8 @@ export class HttpForm extends TD.Form {
 
 Headers.prototype.raw = function () {
     const result: { [key: string]: string[] } = {};
-    for (const h in this.entries()) {
-        result[h[0]] = h[1].split(",");
+    for (const [headerKey, headerValue] of this.entries()) {
+        result[headerKey] = headerValue.split(",");
     }
     return result;
 };

--- a/packages/binding-http/src/routes/thing-description.ts
+++ b/packages/binding-http/src/routes/thing-description.ts
@@ -26,35 +26,31 @@ function resetMultiLangInteraction(
     interactions: ThingDescription["properties"] | ThingDescription["actions"] | ThingDescription["events"],
     prefLang: string
 ) {
-    if (interactions) {
-        for (const interName in interactions) {
+    if (interactions != null) {
+        for (const interaction of Object.values(interactions)) {
             // unset any current title and/or description
-            delete interactions[interName].title;
-            delete interactions[interName].description;
+            delete interaction.title;
+            delete interaction.description;
 
             // use new language title
-            const titles = interactions[interName].titles;
-            if (titles) {
-                for (const titleLang in titles) {
-                    if (titleLang.startsWith(prefLang)) {
-                        interactions[interName].title = titles[titleLang];
-                    }
+            for (const [titleLang, titleValue] of Object.entries(interaction.titles ?? {})) {
+                if (titleLang.startsWith(prefLang)) {
+                    interaction.title = titleValue;
+                    break;
                 }
             }
 
             // use new language description
-            const descriptions = interactions[interName].descriptions;
-            if (descriptions) {
-                for (const descLang in descriptions) {
-                    if (descLang.startsWith(prefLang)) {
-                        interactions[interName].description = descriptions[descLang];
-                    }
+            for (const [descLang, descriptionValue] of Object.entries(interaction.descriptions ?? {})) {
+                if (descLang.startsWith(prefLang)) {
+                    interaction.description = descriptionValue;
+                    break;
                 }
             }
 
             // unset any multilanguage titles and/or descriptions
-            delete interactions[interName].titles;
-            delete interactions[interName].descriptions;
+            delete interaction.titles;
+            delete interaction.descriptions;
         }
     }
 }

--- a/packages/binding-mqtt/src/mqtt-broker-server.ts
+++ b/packages/binding-mqtt/src/mqtt-broker-server.ts
@@ -108,15 +108,15 @@ export default class MqttBrokerServer implements ProtocolServer {
 
         this.things.set(name, thing);
 
-        for (const propertyName in thing.properties) {
+        for (const propertyName of Object.keys(thing.properties)) {
             this.exposeProperty(name, propertyName, thing);
         }
 
-        for (const actionName in thing.actions) {
+        for (const actionName of Object.keys(thing.actions)) {
             this.exposeAction(name, actionName, thing);
         }
 
-        for (const eventName in thing.events) {
+        for (const eventName of Object.keys(thing.events)) {
             this.exposeEvent(name, eventName, thing);
         }
 

--- a/packages/binding-netconf/src/codecs/netconf-codec.ts
+++ b/packages/binding-netconf/src/codecs/netconf-codec.ts
@@ -126,8 +126,9 @@ export default class NetconfCodec {
             let nsFound = false;
             let aliasNs = "";
             let value;
-            for (const key in properties) {
-                const el = properties[key];
+            // TODO: Use correct type for el
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            for (const [key, el] of Object.entries(properties) as [string, any]) {
                 const payloadField = payload[key];
                 if (payloadField == null) {
                     throw new Error(`Payload is missing '${key}' field specified in TD`);

--- a/packages/binding-websockets/src/ws-server.ts
+++ b/packages/binding-websockets/src/ws-server.ts
@@ -120,8 +120,8 @@ export default class WebSocketServer implements ProtocolServer {
     public stop(): Promise<void> {
         debug(`WebSocketServer stopping on port ${this.port}`);
         return new Promise<void>((resolve, reject) => {
-            for (const pathSocket in this.socketServers) {
-                this.socketServers[pathSocket].close();
+            for (const socketServer of Object.values(this.socketServers)) {
+                socketServer.close();
             }
 
             // stop promise handles all errors from now on
@@ -162,7 +162,7 @@ export default class WebSocketServer implements ProtocolServer {
 
             // TODO more efficient routing to ExposedThing without ResourceListeners in each server
 
-            for (const propertyName in thing.properties) {
+            for (const [propertyName, property] of Object.entries(thing.properties)) {
                 const path =
                     "/" +
                     encodeURIComponent(urlPath) +
@@ -170,7 +170,6 @@ export default class WebSocketServer implements ProtocolServer {
                     this.PROPERTY_DIR +
                     "/" +
                     encodeURIComponent(propertyName);
-                const property = thing.properties[propertyName];
 
                 // Populate forms related to the property
                 for (const address of Helpers.getAddresses()) {
@@ -231,26 +230,22 @@ export default class WebSocketServer implements ProtocolServer {
                 });
             }
 
-            for (const actionName in thing.actions) {
+            for (const [actionName, action] of Object.entries(thing.actions)) {
                 const path =
                     "/" + encodeURIComponent(urlPath) + "/" + this.ACTION_DIR + "/" + encodeURIComponent(actionName);
-                // eslint-disable-next-line unused-imports/no-unused-vars
-                const action = thing.actions[actionName];
 
                 for (const address of Helpers.getAddresses()) {
                     const href = `${this.scheme}://${address}:${this.getPort()}${path}`;
                     const form = new TD.Form(href, ContentSerdes.DEFAULT);
                     form.op = ["invokeaction"];
-                    thing.actions[actionName].forms.push(form);
+                    action.forms.push(form);
                     debug(`WebSocketServer on port ${this.getPort()} assigns '${href}' to Action '${actionName}'`);
                 }
             }
 
-            for (const eventName in thing.events) {
+            for (const [eventName, event] of Object.entries(thing.events)) {
                 const path =
                     "/" + encodeURIComponent(urlPath) + "/" + this.EVENT_DIR + "/" + encodeURIComponent(eventName);
-                // eslint-disable-next-line unused-imports/no-unused-vars
-                const event = thing.events[eventName];
 
                 // Populate forms related to the event
                 for (const address of Helpers.getAddresses()) {

--- a/packages/core/src/codecs/netconf-codec.ts
+++ b/packages/core/src/codecs/netconf-codec.ts
@@ -79,8 +79,9 @@ export default class NetconfCodec implements ContentCodec {
             let nsFound = false;
             let aliasNs = "";
             let value;
-            for (const key in properties) {
-                const el = properties[key];
+            // TODO: Use correct type for el
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            for (const [key, el] of Object.entries(properties) as [string, any]) {
                 if (payload[key] == null) {
                     throw new Error(`Payload is missing '${key}' field specified in TD`);
                 }

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -604,11 +604,12 @@ export default class OctetstreamCodec implements ContentCodec {
         }
 
         result = result ?? Buffer.alloc(length);
-        for (const propertyName in schema.properties) {
+        // TODO: Use correct type for propertySchema
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        for (const [propertyName, propertySchema] of Object.entries(schema.properties) as [string, any]) {
             if (Object.hasOwnProperty.call(value, propertyName) === false) {
                 throw new Error(`Missing property '${propertyName}'`);
             }
-            const propertySchema = schema.properties[propertyName];
             const propertyValue = value[propertyName];
             const propertyOffset = parseInt(propertySchema["ex:bitOffset"]);
             const propertyLength = parseInt(propertySchema["ex:bitLength"]);

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -381,19 +381,16 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     }
 
     extendInteractions(): void {
-        for (const propertyName in this.properties) {
-            const newProp = Helpers.extend(
-                this.properties[propertyName],
-                new ConsumedThingProperty(propertyName, this)
-            );
+        for (const [propertyName, property] of Object.entries(this.properties)) {
+            const newProp = Helpers.extend(property, new ConsumedThingProperty(propertyName, this));
             this.properties[propertyName] = newProp;
         }
-        for (const actionName in this.actions) {
-            const newAction = Helpers.extend(this.actions[actionName], new ConsumedThingAction(actionName, this));
+        for (const [actionName, action] of Object.entries(this.actions)) {
+            const newAction = Helpers.extend(action, new ConsumedThingAction(actionName, this));
             this.actions[actionName] = newAction;
         }
-        for (const eventName in this.events) {
-            const newEvent = Helpers.extend(this.events[eventName], new ConsumedThingEvent(eventName, this));
+        for (const [eventName, event] of Object.entries(this.events)) {
+            const newEvent = Helpers.extend(event, new ConsumedThingEvent(eventName, this));
             this.events[eventName] = newEvent;
         }
     }
@@ -612,14 +609,15 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
 
     readAllProperties(options?: WoT.InteractionOptions): Promise<WoT.PropertyReadMap> {
         const propertyNames: string[] = [];
-        for (const propertyName in this.properties) {
+
+        for (const [propertyName, property] of Object.entries(this.properties)) {
             // collect attributes that are "readable" only
-            const tp = this.properties[propertyName];
-            const { form } = this.getClientFor(tp.forms, "readproperty", Affordance.PropertyAffordance, options);
+            const { form } = this.getClientFor(property.forms, "readproperty", Affordance.PropertyAffordance, options);
             if (form != null) {
                 propertyNames.push(propertyName);
             }
         }
+
         return this._readProperties(propertyNames);
     }
 
@@ -656,9 +654,7 @@ export default class ConsumedThing extends TD.Thing implements IConsumedThing {
     async writeMultipleProperties(valueMap: WoT.PropertyWriteMap, options?: WoT.InteractionOptions): Promise<void> {
         // collect all single promises into array
         const promises: Promise<void>[] = [];
-        for (const propertyName in valueMap) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const value = valueMap.get(propertyName)!;
+        for (const [propertyName, value] of valueMap.entries()) {
             promises.push(this.writeProperty(propertyName, value));
         }
         // wait for all promises to succeed and create response

--- a/packages/core/src/exposed-thing.ts
+++ b/packages/core/src/exposed-thing.ts
@@ -458,10 +458,7 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
     public async handleReadAllProperties(
         options: WoT.InteractionOptions & { formIndex: number }
     ): Promise<PropertyContentMap> {
-        const propertyNames: string[] = [];
-        for (const propertyName in this.properties) {
-            propertyNames.push(propertyName);
-        }
+        const propertyNames = Object.keys(this.properties);
         return await this._handleReadProperties(propertyNames, options);
     }
 
@@ -513,16 +510,15 @@ export default class ExposedThing extends TD.Thing implements WoT.ExposedThing {
     ): Promise<void> {
         // collect all single promises into array
         const promises: Promise<void>[] = [];
-        for (const propertyName in valueMap) {
+        for (const [propertyName, property] of Object.entries(valueMap)) {
             // Note: currently only DataSchema properties are supported
             const form = this.properties[propertyName].forms.find(
                 (form) => form.contentType === "application/json" || form.contentType == null
             );
-            if (!form) {
+            if (form == null) {
                 continue;
             }
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know that the property exists
-            promises.push(this.handleWriteProperty(propertyName, valueMap.get(propertyName)!, options));
+            promises.push(this.handleWriteProperty(propertyName, property, options));
         }
         try {
             await Promise.all(promises);

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -87,8 +87,8 @@ export default class Helpers implements Resolver {
         } else {
             const interfaces = os.networkInterfaces();
 
-            for (const iface in interfaces) {
-                interfaces[iface]?.forEach((entry) => {
+            for (const iface of Object.values(interfaces)) {
+                iface?.forEach((entry) => {
                     debug(`AddressHelper found ${entry.address}`);
                     if (entry.internal === false) {
                         if (entry.family === "IPv4") {
@@ -197,12 +197,12 @@ export default class Helpers implements Resolver {
      */
     public static extend<T, U>(first: T, second: U): T & U {
         const result = <T & U>{};
-        for (const id in first) {
-            (<Record<string, unknown>>result)[id] = (<Record<string, unknown>>first)[id];
+        for (const [id, value] of Object.entries(first as Record<string, unknown>)) {
+            (<Record<string, unknown>>result)[id] = value;
         }
-        for (const id in second) {
+        for (const [id, value] of Object.entries(second as Record<string, unknown>)) {
             if (!Object.prototype.hasOwnProperty.call(result, id)) {
-                (<Record<string, unknown>>result)[id] = (<Record<string, unknown>>second)[id];
+                (<Record<string, unknown>>result)[id] = value;
             }
         }
         return result;
@@ -242,9 +242,9 @@ export default class Helpers implements Resolver {
             }
         }
 
-        if (tdSchemaCopy.definitions !== undefined) {
-            for (const prop in tdSchemaCopy.definitions) {
-                tdSchemaCopy.definitions[prop] = this.createExposeThingInitSchema(tdSchemaCopy.definitions[prop]);
+        if (tdSchemaCopy.definitions != null) {
+            for (const [prop, propValue] of Object.entries(tdSchemaCopy.definitions) ?? []) {
+                tdSchemaCopy.definitions[prop] = this.createExposeThingInitSchema(propValue);
             }
         }
 
@@ -307,9 +307,7 @@ export default class Helpers implements Resolver {
             options = { uriVariables: {} };
         }
 
-        for (const varKey in thingUriVariables) {
-            const varValue = thingUriVariables[varKey];
-
+        for (const [varKey, varValue] of Object.entries(thingUriVariables)) {
             if (!(varKey in uriVariables) && "default" in varValue) {
                 uriVariables[varKey] = varValue.default;
             }

--- a/packages/core/src/servient.ts
+++ b/packages/core/src/servient.ts
@@ -54,20 +54,20 @@ export default class Servient {
 
         // initializing forms fields
         thing.forms = [];
-        for (const name in thing.properties) {
+        for (const property of Object.values(thing.properties)) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
-            thing.properties[name].forms = [];
+            property.forms = [];
         }
-        for (const name in thing.actions) {
+        for (const action of Object.values(thing.actions)) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
-            thing.actions[name].forms = [];
+            action.forms = [];
         }
-        for (const name in thing.events) {
+        for (const event of Object.values(thing.events)) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
-            thing.events[name].forms = [];
+            event.forms = [];
         }
 
         const serverPromises: Promise<void>[] = [];
@@ -178,16 +178,13 @@ export default class Servient {
     }
 
     public addCredentials(credentials: Record<string, unknown>): void {
-        if (typeof credentials === "object") {
-            for (const i in credentials) {
-                debug(`Servient storing credentials for '${i}'`);
-                let currentCredentials = this.credentialStore.get(i);
-                if (!currentCredentials) {
-                    currentCredentials = [];
-                    this.credentialStore.set(i, currentCredentials);
-                }
-                currentCredentials.push(credentials[i]);
+        for (const [credentialKey, credentialValue] of Object.entries(credentials ?? {})) {
+            debug(`Servient storing credentials for '${credentialKey}'`);
+            const currentCredentials = this.credentialStore.get(credentialKey) ?? [];
+            if (currentCredentials.length === 0) {
+                this.credentialStore.set(credentialKey, currentCredentials);
             }
+            currentCredentials.push(credentialValue);
         }
     }
 

--- a/packages/td-tools/src/thing-description.ts
+++ b/packages/td-tools/src/thing-description.ts
@@ -36,6 +36,12 @@ export default class Thing implements TDT.ThingDescription {
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     [key: string]: any;
 
+    properties?: { [k: string]: TDT.PropertyElement } | undefined;
+
+    actions?: { [k: string]: TDT.ActionElement } | undefined;
+
+    events?: { [k: string]: TDT.EventElement } | undefined;
+
     constructor() {
         this["@context"] = [DEFAULT_CONTEXT_V1, DEFAULT_CONTEXT_V11];
         this["@type"] = DEFAULT_THING_TYPE;

--- a/packages/td-tools/test/TDParseTest.ts
+++ b/packages/td-tools/test/TDParseTest.ts
@@ -509,13 +509,14 @@ class TDParserTest {
         expect(thing).to.have.property("title").that.equals("MyTemperatureThing");
         expect(thing).to.not.have.property("base");
 
-        expect(thing.properties).to.have.property("temperature");
-        expect(thing.properties.temperature).to.have.property("readOnly").that.equals(false);
-        expect(thing.properties.temperature).to.have.property("observable").that.equals(false);
+        const thingProperties = thing.properties!;
+        expect(thingProperties).to.have.property("temperature");
+        expect(thingProperties.temperature).to.have.property("readOnly").that.equals(false);
+        expect(thingProperties.temperature).to.have.property("observable").that.equals(false);
 
-        expect(thing.properties.temperature).to.have.property("forms").to.have.lengthOf(1);
-        expect(thing.properties.temperature.forms[0]).to.have.property("contentType").that.equals("application/json");
-        expect(thing.properties.temperature.forms[0])
+        expect(thingProperties.temperature).to.have.property("forms").to.have.lengthOf(1);
+        expect(thingProperties.temperature.forms[0]).to.have.property("contentType").that.equals("application/json");
+        expect(thingProperties.temperature.forms[0])
             .to.have.property("href")
             .that.equals("coap://mytemp.example.com:5683/temp");
     }
@@ -529,13 +530,14 @@ class TDParserTest {
         expect(thing).to.have.property("title").that.equals("MyTemperatureThing2");
         expect(thing).to.not.have.property("base");
 
-        expect(thing.properties).to.have.property("temperature");
-        expect(thing.properties.temperature).to.have.property("readOnly").that.equals(false);
-        expect(thing.properties.temperature).to.have.property("observable").that.equals(false);
+        const thingProperties = thing.properties!;
+        expect(thingProperties).to.have.property("temperature");
+        expect(thingProperties.temperature).to.have.property("readOnly").that.equals(false);
+        expect(thingProperties.temperature).to.have.property("observable").that.equals(false);
 
-        expect(thing.properties.temperature).to.have.property("forms").to.have.lengthOf(1);
-        expect(thing.properties.temperature.forms[0]).to.have.property("contentType").that.equals("application/json");
-        expect(thing.properties.temperature.forms[0])
+        expect(thingProperties.temperature).to.have.property("forms").to.have.lengthOf(1);
+        expect(thingProperties.temperature.forms[0]).to.have.property("contentType").that.equals("application/json");
+        expect(thingProperties.temperature.forms[0])
             .to.have.property("href")
             .that.equals("coap://mytemp.example.com:5683/temp");
     }
@@ -549,23 +551,24 @@ class TDParserTest {
         expect(thing).to.have.property("title").that.equals("MyTemperatureThing3");
         expect(thing).to.have.property("base").that.equals("coap://mytemp.example.com:5683/interactions/");
 
-        expect(thing.properties).to.have.property("temperature");
-        expect(thing.properties.temperature).to.have.property("readOnly").that.equals(false);
-        expect(thing.properties.temperature).to.have.property("observable").that.equals(false);
-        expect(thing.properties.temperature).to.have.property("forms").to.have.lengthOf(1);
-        expect(thing.properties.temperature.forms[0]).to.have.property("contentType").that.equals("application/json");
+        const thingProperties = thing.properties!;
+        expect(thingProperties).to.have.property("temperature");
+        expect(thingProperties.temperature).to.have.property("readOnly").that.equals(false);
+        expect(thingProperties.temperature).to.have.property("observable").that.equals(false);
+        expect(thingProperties.temperature).to.have.property("forms").to.have.lengthOf(1);
+        expect(thingProperties.temperature.forms[0]).to.have.property("contentType").that.equals("application/json");
 
-        expect(thing.properties).to.have.property("temperature2");
-        expect(thing.properties.temperature2).to.have.property("readOnly").that.equals(true);
-        expect(thing.properties.temperature2).to.have.property("observable").that.equals(false);
-        expect(thing.properties.temperature2).to.have.property("forms").to.have.lengthOf(1);
-        expect(thing.properties.temperature2.forms[0]).to.have.property("contentType").that.equals("application/json");
+        expect(thingProperties).to.have.property("temperature2");
+        expect(thingProperties.temperature2).to.have.property("readOnly").that.equals(true);
+        expect(thingProperties.temperature2).to.have.property("observable").that.equals(false);
+        expect(thingProperties.temperature2).to.have.property("forms").to.have.lengthOf(1);
+        expect(thingProperties.temperature2.forms[0]).to.have.property("contentType").that.equals("application/json");
 
-        expect(thing.properties).to.have.property("humidity");
-        expect(thing.properties.humidity).to.have.property("readOnly").that.equals(false);
-        expect(thing.properties.humidity).to.have.property("observable").that.equals(false);
-        expect(thing.properties.humidity).to.have.property("forms").to.have.lengthOf(1);
-        expect(thing.properties.humidity.forms[0]).to.have.property("contentType").that.equals("application/json");
+        expect(thingProperties).to.have.property("humidity");
+        expect(thingProperties.humidity).to.have.property("readOnly").that.equals(false);
+        expect(thingProperties.humidity).to.have.property("observable").that.equals(false);
+        expect(thingProperties.humidity).to.have.property("forms").to.have.lengthOf(1);
+        expect(thingProperties.humidity.forms[0]).to.have.property("contentType").that.equals("application/json");
     }
 
     // TODO: wait for exclude https://github.com/chaijs/chai/issues/885
@@ -623,17 +626,18 @@ class TDParserTest {
         // thing metadata "reference": "myTempThing" in metadata
         expect(thing).to.have.property("reference").that.equals("myTempThing");
 
-        expect(thing.properties).to.have.property("myTemp");
-        expect(thing.properties.myTemp).to.have.property("readOnly").that.equals(true);
-        expect(thing.properties.myTemp).to.have.property("observable").that.equals(false);
-        expect(thing.properties.myTemp).to.have.property("forms").to.have.lengthOf(1);
-        expect(thing.properties.myTemp.forms[0]).to.have.property("contentType").that.equals("application/json");
+        const thingProperties = thing.properties!;
+        expect(thingProperties).to.have.property("myTemp");
+        expect(thingProperties.myTemp).to.have.property("readOnly").that.equals(true);
+        expect(thingProperties.myTemp).to.have.property("observable").that.equals(false);
+        expect(thingProperties.myTemp).to.have.property("forms").to.have.lengthOf(1);
+        expect(thingProperties.myTemp.forms[0]).to.have.property("contentType").that.equals("application/json");
 
         // metadata
         // metadata "unit": "celsius"
-        expect(thing.properties.myTemp).to.have.property("unit").that.equals("celsius");
+        expect(thingProperties.myTemp).to.have.property("unit").that.equals("celsius");
         // metadata "reference": "threshold"
-        expect(thing.properties.myTemp).to.have.property("reference").that.equals("threshold");
+        expect(thingProperties.myTemp).to.have.property("reference").that.equals("threshold");
 
         // serialize
         // const newJson = TDParser.serializeTD(thing);
@@ -645,21 +649,22 @@ class TDParserTest {
 
         expect(thing).to.have.property("base").that.equals("coap://mytemp.example.com:5683/interactions/");
 
-        expect(thing.properties.temperature.forms[0])
+        const thingProperties = thing.properties!;
+        expect(thingProperties.temperature.forms[0])
             .to.have.property("href")
             .that.equals("coap://mytemp.example.com:5683/interactions/temp");
-        expect(thing.properties.temperature2.forms[0])
+        expect(thingProperties.temperature2.forms[0])
             .to.have.property("href")
             .that.equals("coap://mytemp.example.com:5683/interactions/temp");
-        expect(thing.properties.humidity.forms[0])
+        expect(thingProperties.humidity.forms[0])
             .to.have.property("href")
             .that.equals("coap://mytemp.example.com:5683/humid");
 
-        expect(thing.actions.reset.forms[0])
+        expect(thing.actions!.reset.forms[0])
             .to.have.property("href")
             .that.equals("coap://mytemp.example.com:5683/actions/reset");
 
-        expect(thing.events.update.forms[0])
+        expect(thing.events!.update.forms[0])
             .to.have.property("href")
             .that.equals("coap://mytemp.example.com:5683/interactions/events/update");
     }
@@ -678,9 +683,11 @@ class TDParserTest {
         expect(thing).to.have.property("events");
 
         logDebug(`${thing["@context"]}`);
-        expect(thing.properties).to.have.property("status");
-        expect(thing.properties.status.readOnly).equals(true);
-        expect(thing.properties.status.observable).equals(false);
+
+        const thingProperties = thing.properties!;
+        expect(thingProperties).to.have.property("status");
+        expect(thingProperties.status.readOnly).equals(true);
+        expect(thingProperties.status.observable).equals(false);
     }
 
     @test "simplified TD 1.1"() {
@@ -697,9 +704,11 @@ class TDParserTest {
         expect(thing).to.have.property("events");
 
         logDebug(`${thing["@context"]}`);
-        expect(thing.properties).to.have.property("status");
-        expect(thing.properties.status.readOnly).equals(true);
-        expect(thing.properties.status.observable).equals(false);
+
+        const thingProperties = thing.properties!;
+        expect(thingProperties).to.have.property("status");
+        expect(thingProperties.status.readOnly).equals(true);
+        expect(thingProperties.status.observable).equals(false);
     }
 
     @test "should detect broken TDs"() {
@@ -775,14 +784,16 @@ class TDParserTest {
         // interaction arrays
         expect(thing).to.have.property("properties");
 
-        expect(thing.properties).to.have.property("without");
-        expect(thing.properties.without.forms[0].href).equals("coap://localhost:8080/uv/" + "without{?step}");
+        const thingProperties = thing.properties!;
 
-        expect(thing.properties).to.have.property("with1");
-        expect(thing.properties.with1.forms[0].href).equals("coap://localhost:8080/uv/" + "with1{?step}");
+        expect(thingProperties).to.have.property("without");
+        expect(thingProperties.without.forms[0].href).equals("coap://localhost:8080/uv/" + "without{?step}");
 
-        expect(thing.properties).to.have.property("with2");
-        expect(thing.properties.with2.forms[0].href).equals("coap://localhost:8080/uv/" + "with2{?step,a}");
+        expect(thingProperties).to.have.property("with1");
+        expect(thingProperties.with1.forms[0].href).equals("coap://localhost:8080/uv/" + "with1{?step}");
+
+        expect(thingProperties).to.have.property("with2");
+        expect(thingProperties.with2.forms[0].href).equals("coap://localhost:8080/uv/" + "with2{?step,a}");
     }
 
     @test "uriVarables in combination with and without coap base"() {
@@ -832,13 +843,15 @@ class TDParserTest {
         // interaction arrays
         expect(thing).to.have.property("properties");
 
-        expect(thing.properties).to.have.property("without");
-        expect(thing.properties.without.forms[0].href).equals("http://localhost:8080/uv/" + "without{?step}");
+        const thingProperties = thing.properties!;
 
-        expect(thing.properties).to.have.property("with1");
-        expect(thing.properties.with1.forms[0].href).equals("http://localhost:8080/uv/" + "with1{?step}");
+        expect(thingProperties).to.have.property("without");
+        expect(thingProperties.without.forms[0].href).equals("http://localhost:8080/uv/" + "without{?step}");
 
-        expect(thing.properties).to.have.property("with2");
-        expect(thing.properties.with2.forms[0].href).equals("http://localhost:8080/uv/" + "with2{?step,a}");
+        expect(thingProperties).to.have.property("with1");
+        expect(thingProperties.with1.forms[0].href).equals("http://localhost:8080/uv/" + "with1{?step}");
+
+        expect(thingProperties).to.have.property("with2");
+        expect(thingProperties.with2.forms[0].href).equals("http://localhost:8080/uv/" + "with2{?step,a}");
     }
 }


### PR DESCRIPTION
(Not only) in the context of #1177, I noticed that some of the for loops use the `for ... in` syntax instead of the `for ... of` syntax. Apparently, the former style is discouraged and not recommended by eslint, for example (see https://eslint.org/docs/latest/rules/guard-for-in).

This PR replaces the code lines in question and enforces the new style by activating the `guard-for-in` eslint rule.