### PR TITLE
fix(interaction-output): adjust storing behavior and return type of `value` method

### DIFF
--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -79,7 +79,9 @@ export class InteractionOutput implements WoT.InteractionOutput {
 
     async value<T>(): Promise<T> {
         // the value has been already read?
-        if (this.parsedValue != null) return this.parsedValue as T;
+        if (this.parsedValue !== undefined) {
+            return this.parsedValue as T;
+        }
 
         if (this.dataUsed) {
             throw new Error("Can't read the stream once it has been already used");

--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -77,7 +77,7 @@ export class InteractionOutput implements WoT.InteractionOutput {
         return data;
     }
 
-    async value<T>(): Promise<T> {
+    async value<T extends WoT.DataSchemaValue>(): Promise<T> {
         // the value has been already read?
         if (this.parsedValue !== undefined) {
             return this.parsedValue as T;


### PR DESCRIPTION
While dealing with the `InteractionOutput` class, I noticed that a small bug (due to the `!= null` check) was introduced that prevents already `parsedValue`s of type `null` from being properly returned. This PR solves the issue by replacing the check with `!== undefined`, so that `null` values are not being ignored anymore.