### PR TITLE
test(coap-server): don't shutdown servient unnecessarily

### DIFF
--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -598,14 +598,13 @@ class CoapServerTest {
         });
 
         await coapServer.stop();
-        await servient.shutdown();
     }
 
     @test async "should reject unsupported methods for meta operations"() {
         const coapServer = new CoapServer();
         const servient = new Servient();
 
-        await coapServer.start(servient);
+        await coapServer.start(new Servient());
 
         const testThingWithoutForms = new ExposedThing(servient, {
             title: "Test",
@@ -634,6 +633,5 @@ class CoapServerTest {
         });
 
         await coapServer.stop();
-        await servient.shutdown();
     }
 }


### PR DESCRIPTION
This PR contains a potential fix for the CoAP server problems observed in #1195. As the servients are not used by the `CoapServer` class, I simply removed the invocations of `shutdown` to fix the issue at hand.

In general, I think we could discuss if passing the servient to the protocol interface implementations is actually necessary or if the passing of protocol-specific callbacks for retrieving credentials could be an alternative (this is the approach I used for dart_wot in the meantime). But I would open a dedicated issue for that later :)