### PR TITLE
fix(binding-file): improve file-client implementation

### DIFF
--- a/packages/binding-file/test/.gitignore
+++ b/packages/binding-file/test/.gitignore
@@ -1,2 +1,3 @@
 # Ignore auxiliary files created by the FileClient implementation tests
-test.*
+test*.json
+test*.txt


### PR DESCRIPTION
This PR tries to make the file-client implementation more reliable by replacing the synchronous `fs` code with asynchronous alternatives from `fs/promises`. I am not sure how much of a difference this will make, but I hope this change will resolve the issues we have been observing since the merging of https://github.com/eclipse-thingweb/node-wot/pull/1175.