### PR TITLE
fix(coap-server): add missing cov:observe subprotocol

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -32,13 +32,15 @@ import { Server, createServer, registerFormat, IncomingMessage, OutgoingMessage 
 import slugify from "slugify";
 import { Readable } from "stream";
 import { MdnsIntroducer } from "./mdns-introducer";
-import { PropertyElement, DataSchema } from "wot-thing-description-types";
+import { PropertyElement, DataSchema, ActionElement, EventElement } from "wot-thing-description-types";
 import { CoapServerConfig } from "./coap";
 import { DataSchemaValue } from "wot-typescript-definitions";
 
 const { debug, warn, info, error } = createLoggers("binding-coap", "coap-server");
 
 type CoreLinkFormatParameters = Map<string, string[] | number[]>;
+
+type AffordanceElement = PropertyElement | ActionElement | EventElement;
 
 // TODO: Move to core?
 type AugmentedInteractionOptions = WoT.InteractionOptions & { formIndex: number };
@@ -228,6 +230,15 @@ export default class CoapServer implements ProtocolServer {
         return opValues;
     }
 
+    private addFormToAffordance(form: TD.Form, affordance: AffordanceElement): void {
+        const affordanceForms = affordance.forms;
+        if (affordanceForms == null) {
+            affordance.forms ??= [form];
+        } else {
+            affordanceForms.push(form);
+        }
+    }
+
     private fillInPropertyBindingData(thing: ExposedThing, base: string, offeredMediaType: string) {
         for (const [propertyName, property] of Object.entries(thing.properties)) {
             const opValues = ProtocolHelpers.getPropertyOpValues(property);
@@ -241,7 +252,7 @@ export default class CoapServer implements ProtocolServer {
                 property.uriVariables
             );
 
-            property.forms.push(form);
+            this.addFormToAffordance(form, property);
             this.logHrefAssignment(form, "Property", propertyName);
         }
     }
@@ -258,7 +269,7 @@ export default class CoapServer implements ProtocolServer {
                 action.uriVariables
             );
 
-            action.forms.push(form);
+            this.addFormToAffordance(form, action);
             this.logHrefAssignment(form, "Action", actionName);
         }
     }
@@ -275,7 +286,7 @@ export default class CoapServer implements ProtocolServer {
                 event.uriVariables
             );
 
-            event.forms.push(form);
+            this.addFormToAffordance(form, event);
             this.logHrefAssignment(form, "Event", eventName);
         }
     }

--- a/packages/binding-coap/src/util.ts
+++ b/packages/binding-coap/src/util.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+import { ProtocolHelpers } from "@node-wot/core";
+import { PropertyElement } from "wot-thing-description-types";
+
+const observeOpFilter = ["observeproperty", "unobserveproperty"];
+const readWriteOpFilter = ["readproperty", "writeproperty"];
+
+function filterOpValues(opValues: string[], filterValues: string[]) {
+    return opValues.filter((opValue) => filterValues.includes(opValue));
+}
+
+/**
+ * Convenience function to filter out the `op` values "observeproperty" and
+ * "unobserveproperty" from a string array.
+ *
+ * @param opValues The `op` values to be filtered.
+ * @returns A filtered array that might be empty.
+ */
+export function filterPropertyObserveOperations(opValues: string[]) {
+    return filterOpValues(opValues, observeOpFilter);
+}
+
+/**
+ * Convenience function to filter out the `op` values "readproperty" and
+ * "writeproperty" from a string array.
+ *
+ * @param opValues The `op` values to be filtered.
+ * @returns A filtered array that might be empty.
+ */
+function filterPropertyReadWriteOperations(opValues: string[]) {
+    return filterOpValues(opValues, readWriteOpFilter);
+}
+
+/**
+ * Function to (potentially) generate two arrays of `op` values: One with the
+ * values "readproperty" and "writeproperty", and one with
+ * "observerproperty" and "unobserveproperty".
+ *
+ * This CoAP-specific distinction is made to be able to generate
+ * separate forms for the observe-related operations, where the addition
+ * of a `subprotocol` field with a value of `cov:observe` has to be added.
+ *
+ * @param property The property for which the forms are going to be
+ *                 generated.
+ * @returns A tuple consisting of two op value arrays (one for read and
+ *          write operations, one for observe-related operations).
+ */
+export function getPropertyOpValues(property: PropertyElement) {
+    const opValues = ProtocolHelpers.getPropertyOpValues(property);
+
+    const readWriteOpValues = filterPropertyReadWriteOperations(opValues);
+    const observeOpValues = filterPropertyObserveOperations(opValues);
+
+    return [readWriteOpValues, observeOpValues];
+}

--- a/packages/binding-coap/src/util.ts
+++ b/packages/binding-coap/src/util.ts
@@ -18,6 +18,7 @@ import { PropertyElement } from "wot-thing-description-types";
 
 const observeOpFilter = ["observeproperty", "unobserveproperty"];
 const readWriteOpFilter = ["readproperty", "writeproperty"];
+const eventOpFilter = ["subscribeevent", "unsubscribeevent"];
 
 function filterOpValues(opValues: string[], filterValues: string[]) {
     return opValues.filter((opValue) => filterValues.includes(opValue));
@@ -41,8 +42,19 @@ export function filterPropertyObserveOperations(opValues: string[]) {
  * @param opValues The `op` values to be filtered.
  * @returns A filtered array that might be empty.
  */
-function filterPropertyReadWriteOperations(opValues: string[]) {
+export function filterPropertyReadWriteOperations(opValues: string[]) {
     return filterOpValues(opValues, readWriteOpFilter);
+}
+
+/**
+ * Convenience function to filter out the `op` values "subscribeevent" and
+ * "unsubscribeevent" from a string array.
+ *
+ * @param opValues The `op` values to be filtered.
+ * @returns A filtered array that might be empty.
+ */
+export function filterEventOperations(opValues: string[]) {
+    return filterOpValues(opValues, eventOpFilter);
 }
 
 /**


### PR DESCRIPTION
Trying to interact with a test thing using CoAP, I noticed that the forms provided in the Thing Descriptions do not include the `subprotocol` value `cov:observe` for observable properties and events. This PR tries to fix the issue by adding logic to determine if a `subprotocol` should be added to a form.

The implementation got a bit more complicated than initially expected because I noticed that you probably should not simply add the subprotocol to all property forms, but only those containing the op values `observeproperty` and/or `unobserveproperty`. Furthermore, I got the feeling that you should not use `cov:observe` with `readproperty` or `writeproperty` (which I think is currently not clearly stated in the CoAP Binding Template).

Therefore, during the TD generation process, I split the op values for read/write operations and observe/unobserve operations, and generated separate forms for the two kinds of operations. There might be some more discussion and clarification in the protocol binding document needed to decide whether `cov:observe` should or should not be used with forms containing `readproperty` and/or `writeproperty`. In general, the approach in this PR should work regardless of the eventual decision, though.

Besides the actual implementation, I performed some minor refactoring of the process of assigning the forms to affordances and added a test to cover all changes made.