### PR TITLE
Align `value` function to Scripting API

### DIFF
--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -160,7 +160,7 @@ class HttpServerTest {
         let test: DataSchemaValue;
         testThing.setPropertyReadHandler("test", (_) => Promise.resolve(test));
         testThing.setPropertyWriteHandler("test", async (value) => {
-            test = await value.value();
+            test = Buffer.from(await value.arrayBuffer()).toString("utf-8");
         });
 
         testThing.setActionHandler("try", async (input: WoT.InteractionOutput) => {

--- a/packages/binding-opcua/test/full-opcua-thing-test.ts
+++ b/packages/binding-opcua/test/full-opcua-thing-test.ts
@@ -371,7 +371,7 @@ describe("Full OPCUA Thing Test", () => {
             const content = await thing.readProperty(propertyName, localOptions);
             if (forceParsing) {
                 // In opcua binding it is possible to return a special response that contains
-                // reacher details than the bare value. However this make the returned value
+                // richer details than the bare value. However this makes the returned value
                 // not complaint with its data schema. Therefore we have to fallback to
                 // custom parsing.
                 const raw = await content.arrayBuffer();

--- a/packages/binding-opcua/test/full-opcua-thing-test.ts
+++ b/packages/binding-opcua/test/full-opcua-thing-test.ts
@@ -49,6 +49,7 @@ const thingDescription: WoT.ThingDescription = {
             observable: true,
             readOnly: true,
             unit: "°C",
+            type: "number",
             "opcua:nodeId": { root: "i=84", path: "/Objects/1:MySensor/2:ParameterSet/1:Temperature" },
             // Don't specifu type here as it could be multi form: type: [ "object", "number" ],
             forms: [
@@ -111,6 +112,7 @@ const thingDescription: WoT.ThingDescription = {
             description: "the temperature set point",
             observable: true,
             unit: "°C",
+            type: "number",
             // dont't
             forms: [
                 {
@@ -358,10 +360,25 @@ describe("Full OPCUA Thing Test", () => {
 
         return { thing, servient };
     }
-    async function doTest(thing: WoT.ConsumedThing, propertyName: string, localOptions: InteractionOptions) {
+    async function doTest(
+        thing: WoT.ConsumedThing,
+        propertyName: string,
+        localOptions: InteractionOptions,
+        forceParsing = false
+    ) {
         debug("------------------------------------------------------");
         try {
             const content = await thing.readProperty(propertyName, localOptions);
+            if (forceParsing) {
+                // In opcua binding it is possible to return a special response that contains
+                // reacher details than the bare value. However this make the returned value
+                // not complaint with its data schema. Therefore we have to fallback to
+                // custom parsing.
+                const raw = await content.arrayBuffer();
+                const json = JSON.parse(Buffer.from(raw).toString("utf-8"));
+                debug(json?.toString());
+                return json;
+            }
             const json = await content.value();
             debug(json?.toString());
             return json;
@@ -395,13 +412,13 @@ describe("Full OPCUA Thing Test", () => {
             const json1 = await doTest(thing, propertyName, { formIndex: 1 });
             expect(json1).to.eql(25);
 
-            const json2 = await doTest(thing, propertyName, { formIndex: 2 });
+            const json2 = await doTest(thing, propertyName, { formIndex: 2 }, true);
             expect(json2).to.eql({ Type: 11, Body: 25 });
 
             expect(thingDescription.properties?.temperature.forms[3].contentType).eql(
                 "application/opcua+json;type=DataValue"
             );
-            const json3 = await doTest(thing, propertyName, { formIndex: 3 });
+            const json3 = await doTest(thing, propertyName, { formIndex: 3 }, true);
             debug(json3?.toString());
             expect((json3 as Record<string, unknown>).Value).to.eql({ Type: 11, Body: 25 });
         } finally {

--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -106,7 +106,6 @@ export class InteractionOutput implements WoT.InteractionOutput {
         this.dataUsed = true;
         this.buffer = bytes;
 
-        // call the contentToValue
         const json = ContentSerdes.get().contentToValue({ type: this.content.type, body: bytes }, this.schema);
 
         // validate the schema
@@ -120,6 +119,6 @@ export class InteractionOutput implements WoT.InteractionOutput {
         }
 
         this.#value = json;
-        return this.#value as T;
+        return json;
     }
 }

--- a/packages/core/test/DiscoveryTest.ts
+++ b/packages/core/test/DiscoveryTest.ts
@@ -36,6 +36,7 @@ function createDirectoryTestTd(title: string, thingsPropertyHref: string) {
         },
         properties: {
             things: {
+                type: "array",
                 forms: [
                     {
                         href: thingsPropertyHref,


### PR DESCRIPTION
As discussed in #1216, the current implementation of the value function didn't take into account the validation of the DataSchema of the target affordance. This PR fix #1216 but it also introduces some required changes to take into account the new behavior in other places of the codebase. In particular, it updates the `exploreDirectory` method and `ThingDiscoveryProcess` class moving the fetching of the list of ThingDescirption from the method to the async iterator. The main reason for this change is that I figured out that with a DataSchema the `readProperty` would throw before entering even starting the `ThingDiscoveryProcess` which would be strange and violate the contract of the method `exploreDirectory` (errors for the list should be conveyed as errors in the ThingDesscovery object). Plus it has the benefit of lazy loading the list of TDs and they might be even controlled with `limit` and `offset` later. Handling the case in which the TDD does not have the DataSchema declared is still a TODO (but I can include in this PR). 

Finally, I fixed a minor problem in the binding-file that was preventing a clean test run on my local machine. 