### PR TITLE
fix(octet-stream): correct limits for integer serialization and add tests

### DIFF
--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -372,11 +372,11 @@ export default class OctetstreamCodec implements ContentCodec {
         // throw error on overflow
         if (signed) {
             if (value < -limit - 1 || value > limit) {
-                throw new Error("Integer overflow when representing signed " + value + " in " + length + " bit(s)");
+                throw new Error("Integer overflow when representing " + value + " as a signed integer using " + length + " bit(s)");
             }
         } else {
             if (value < 0 || value > limit) {
-                throw new Error("Integer overflow when representing unsigned " + value + " in " + length + " bit(s)");
+                throw new Error("Integer overflow when representing " + value + " as an unsigned integer using " + length + " bit(s)");
             }
         }
 

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -371,11 +371,11 @@ export default class OctetstreamCodec implements ContentCodec {
         const limit = Math.pow(2, signed ? length - 1 : length) - 1;
         // throw error on overflow
         if (signed) {
-            if (value < -limit - 1 || value >= limit) {
+            if (value < -limit - 1 || value > limit) {
                 throw new Error("Integer overflow when representing signed " + value + " in " + length + " bit(s)");
             }
         } else {
-            if (value < 0 || value >= limit) {
+            if (value < 0 || value > limit) {
                 throw new Error("Integer overflow when representing unsigned " + value + " in " + length + " bit(s)");
             }
         }

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -372,11 +372,19 @@ export default class OctetstreamCodec implements ContentCodec {
         // throw error on overflow
         if (signed) {
             if (value < -limit - 1 || value > limit) {
-                throw new Error("Integer overflow when representing " + value + " as a signed integer using " + length + " bit(s)");
+                throw new Error(
+                    "Integer overflow when representing " + value + " as a signed integer using " + length + " bit(s)"
+                );
             }
         } else {
             if (value < 0 || value > limit) {
-                throw new Error("Integer overflow when representing " + value + " as an unsigned integer using " + length + " bit(s)");
+                throw new Error(
+                    "Integer overflow when representing " +
+                        value +
+                        " as an unsigned integer using " +
+                        length +
+                        " bit(s)"
+                );
             }
         }
 

--- a/packages/core/test/ContentSerdesTest.ts
+++ b/packages/core/test/ContentSerdesTest.ts
@@ -578,6 +578,30 @@ class SerdesOctetTests {
         body = await content.toBuffer();
         expect(body).to.deep.equal(Buffer.from([0x80, 0x44]));
 
+        content = await ContentSerdes.valueToContent(
+            255,
+            { type: "uint8" },
+            `application/octet-stream;byteSeq=${Endianness.LITTLE_ENDIAN};length=1;`
+        );
+        body = await content.toBuffer();
+        expect(body).to.deep.equal(Buffer.from([0xff]));
+
+        content = await ContentSerdes.valueToContent(
+            127,
+            { type: "int8" },
+            `application/octet-stream;signed=true;length=1;`
+        );
+        body = await content.toBuffer();
+        expect(body).to.deep.equal(Buffer.from([0x7f]));
+
+        content = await ContentSerdes.valueToContent(
+            -128,
+            { type: "int8" },
+            `application/octet-stream;signed=true;length=1;`
+        );
+        body = await content.toBuffer();
+        expect(body).to.deep.equal(Buffer.from([0x80]));
+
         content = ContentSerdes.valueToContent(
             2345,
             { type: "integer", "ex:bitLength": 24 },
@@ -742,11 +766,23 @@ class SerdesOctetTests {
     }
 
     @test "value to OctetStream should throw"() {
-        // @ts-ignore new dataschema types are not yet supported in the td type definitions
-        expect(() => ContentSerdes.valueToContent(2345, { type: "int8" }, "application/octet-stream")).to.throw(
+        expect(() => ContentSerdes.valueToContent(256, { type: "uint8" }, "application/octet-stream")).to.throw(
             Error,
-            "Integer overflow when representing signed 2345 in 8 bit(s)"
+            "Integer overflow when representing unsigned 256 in 8 bit(s)"
         );
+        expect(() => ContentSerdes.valueToContent(-1, { type: "uint8" }, "application/octet-stream")).to.throw(
+            Error,
+            "Integer overflow when representing unsigned -1 in 8 bit(s)"
+        );
+        expect(() => ContentSerdes.valueToContent(128, { type: "int8" }, "application/octet-stream")).to.throw(
+            Error,
+            "Integer overflow when representing signed 128 in 8 bit(s)"
+        );
+        expect(() => ContentSerdes.valueToContent(-129, { type: "int8" }, "application/octet-stream")).to.throw(
+            Error,
+            "Integer overflow when representing signed -129 in 8 bit(s)"
+        );
+
         // @ts-ignore new dataschema types are not yet supported in the td type definitions
         expect(() => ContentSerdes.valueToContent(23450000, { type: "int16" }, "application/octet-stream")).to.throw(
             Error,

--- a/packages/core/test/ContentSerdesTest.ts
+++ b/packages/core/test/ContentSerdesTest.ts
@@ -768,25 +768,25 @@ class SerdesOctetTests {
     @test "value to OctetStream should throw"() {
         expect(() => ContentSerdes.valueToContent(256, { type: "uint8" }, "application/octet-stream")).to.throw(
             Error,
-            "Integer overflow when representing unsigned 256 in 8 bit(s)"
+            "Integer overflow when representing 256 as an unsigned integer using 8 bit(s)"
         );
         expect(() => ContentSerdes.valueToContent(-1, { type: "uint8" }, "application/octet-stream")).to.throw(
             Error,
-            "Integer overflow when representing unsigned -1 in 8 bit(s)"
+            "Integer overflow when representing -1 as an unsigned integer using 8 bit(s)"
         );
         expect(() => ContentSerdes.valueToContent(128, { type: "int8" }, "application/octet-stream")).to.throw(
             Error,
-            "Integer overflow when representing signed 128 in 8 bit(s)"
+            "Integer overflow when representing 128 as a signed integer using 8 bit(s)"
         );
         expect(() => ContentSerdes.valueToContent(-129, { type: "int8" }, "application/octet-stream")).to.throw(
             Error,
-            "Integer overflow when representing signed -129 in 8 bit(s)"
+            "Integer overflow when representing -129 as a signed integer using 8 bit(s)"
         );
 
         // @ts-ignore new dataschema types are not yet supported in the td type definitions
         expect(() => ContentSerdes.valueToContent(23450000, { type: "int16" }, "application/octet-stream")).to.throw(
             Error,
-            "Integer overflow when representing signed 23450000 in 16 bit(s)"
+            "Integer overflow when representing 23450000 as a signed integer using 16 bit(s)"
         );
         expect(() => ContentSerdes.valueToContent(2345, { type: "foo" }, "application/octet-stream")).to.throw(
             Error,
@@ -804,14 +804,14 @@ class SerdesOctetTests {
                 { type: "integer", "ex:bitOffset": 0, "ex:bitLength": 10 },
                 "application/octet-stream"
             )
-        ).to.throw(Error, "Integer overflow when representing signed -2345 in 10 bit(s)");
+        ).to.throw(Error, "Integer overflow when representing -2345 as a signed integer using 10 bit(s)");
         expect(() =>
             ContentSerdes.valueToContent(
                 -32769,
                 { type: "integer", "ex:bitOffset": 0, "ex:bitLength": 16 },
                 "application/octet-stream"
             )
-        ).to.throw(Error, "Integer overflow when representing signed -32769 in 16 bit(s)");
+        ).to.throw(Error, "Integer overflow when representing -32769 as a signed integer using 16 bit(s)");
         expect(() =>
             ContentSerdes.valueToContent(
                 { flag1: true, flag2: false, numberProperty: 99, stringProperty: "Web" },


### PR DESCRIPTION
I noticed that the limits for integer serialization are wrong and corrected them. Additionally, I added test for these limits.

Changes in `octetstream-codec.ts`
- serializing `255` as unsigned integer with 8 bits failed, succeeds now;
- serializing `127` as signed integer with 8 bits failed, succeeds new;

Changes in `ContentSerdesTest.ts`
- added tests verifying that `255` as `uint8`, `127` and `-128` as `int8` succeed
- added tests verifying that `256` and `-1` as`unit8`, `128` and `-129` as `int8` fail 