### PR TITLE
chore: increase version numbers to 0.8.13 for next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,9 +61,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
-            "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
+            "version": "7.23.9",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+            "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -152,11 +152,33 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
+        },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/@eslint/js": {
             "version": "8.56.0",
@@ -168,17 +190,39 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
                 "node": ">=10.10.0"
+            }
+        },
+        "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -195,9 +239,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+            "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
         "node_modules/@istanbuljs/schema": {
@@ -378,11 +422,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@peculiar/asn1-csr": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.8.tgz",
@@ -394,11 +433,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@peculiar/asn1-ecc": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.8.tgz",
@@ -409,11 +443,6 @@
                 "asn1js": "^3.0.5",
                 "tslib": "^2.6.2"
             }
-        },
-        "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-pfx": {
             "version": "2.3.8",
@@ -428,11 +457,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@peculiar/asn1-pkcs8": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.8.tgz",
@@ -443,11 +467,6 @@
                 "asn1js": "^3.0.5",
                 "tslib": "^2.6.2"
             }
-        },
-        "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-pkcs9": {
             "version": "2.3.8",
@@ -464,11 +483,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@peculiar/asn1-rsa": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.8.tgz",
@@ -480,11 +494,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@peculiar/asn1-schema": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
@@ -494,11 +503,6 @@
                 "pvtsutils": "^1.3.5",
                 "tslib": "^2.6.2"
             }
-        },
-        "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/asn1-x509": {
             "version": "2.3.8",
@@ -523,16 +527,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-        "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@peculiar/json-schema": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
@@ -544,30 +538,20 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@peculiar/json-schema/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@peculiar/webcrypto": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-            "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.5.tgz",
+            "integrity": "sha512-oDk93QCDGdxFRM8382Zdminzs44dg3M2+E5Np+JWkpqLDyJC9DviMh8F8mEJkYuUcUOGA5jHO5AJJ10MFWdbZw==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
                 "@peculiar/json-schema": "^1.1.12",
-                "pvtsutils": "^1.3.2",
-                "tslib": "^2.5.0",
-                "webcrypto-core": "^1.7.7"
+                "pvtsutils": "^1.3.5",
+                "tslib": "^2.6.2",
+                "webcrypto-core": "^1.7.8"
             },
             "engines": {
                 "node": ">=10.12.0"
             }
-        },
-        "node_modules/@peculiar/webcrypto/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@peculiar/x509": {
             "version": "1.9.6",
@@ -586,11 +570,6 @@
                 "tslib": "^2.6.2",
                 "tsyringe": "^4.8.0"
             }
-        },
-        "node_modules/@peculiar/x509/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@petamoriken/float16": {
             "version": "3.8.4",
@@ -685,9 +664,9 @@
             "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         },
         "node_modules/@serialport/bindings/node_modules/node-abi": {
-            "version": "3.52.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
-            "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
+            "version": "3.54.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
+            "integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -1135,9 +1114,9 @@
             }
         },
         "node_modules/@types/dns-packet": {
-            "version": "5.6.4",
-            "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.4.tgz",
-            "integrity": "sha512-R0ORTvCCeujG+upKfV4JlvozKLdQWlpsducXGd1L6ezBChwpjSj9K84F+KoMDsZQ9RhOLTR1hnNrwJHWagY24g==",
+            "version": "5.6.5",
+            "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+            "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1160,9 +1139,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.41",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-            "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+            "version": "4.17.42",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
+            "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -1216,12 +1195,6 @@
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "dev": true
         },
-        "node_modules/@types/minimatch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-            "dev": true
-        },
         "node_modules/@types/mkdirp": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
@@ -1257,9 +1230,9 @@
             "integrity": "sha512-yqU2Rf94HFZqgHf6Tuyc/IqVD0l3U91KjvypSr1GtJKyrnl6L/kfnxVqN4QOwcF5Zx9tO/HKK+fozGr5AtqA+g=="
         },
         "node_modules/@types/node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+            "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -1281,9 +1254,9 @@
             }
         },
         "node_modules/@types/qs": {
-            "version": "6.9.10",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-            "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
+            "version": "6.9.11",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
+            "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
@@ -1381,16 +1354,16 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
-            "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.1.tgz",
+            "integrity": "sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/type-utils": "6.15.0",
-                "@typescript-eslint/utils": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.19.1",
+                "@typescript-eslint/type-utils": "6.19.1",
+                "@typescript-eslint/utils": "6.19.1",
+                "@typescript-eslint/visitor-keys": "6.19.1",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -1416,15 +1389,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
-            "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.1.tgz",
+            "integrity": "sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/typescript-estree": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.19.1",
+                "@typescript-eslint/types": "6.19.1",
+                "@typescript-eslint/typescript-estree": "6.19.1",
+                "@typescript-eslint/visitor-keys": "6.19.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1444,13 +1417,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
-            "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
+            "integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0"
+                "@typescript-eslint/types": "6.19.1",
+                "@typescript-eslint/visitor-keys": "6.19.1"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1461,13 +1434,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
-            "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
+            "integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.15.0",
-                "@typescript-eslint/utils": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.19.1",
+                "@typescript-eslint/utils": "6.19.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -1488,9 +1461,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
-            "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
+            "integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1501,16 +1474,17 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
-            "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
+            "integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0",
+                "@typescript-eslint/types": "6.19.1",
+                "@typescript-eslint/visitor-keys": "6.19.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
+                "minimatch": "9.0.3",
                 "semver": "^7.5.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -1528,17 +1502,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
-            "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
+            "integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.19.1",
+                "@typescript-eslint/types": "6.19.1",
+                "@typescript-eslint/typescript-estree": "6.19.1",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -1553,12 +1527,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
-            "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
+            "version": "6.19.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
+            "integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/types": "6.19.1",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -1611,9 +1585,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1663,9 +1637,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
-            "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+            "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1919,15 +1893,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/array-differ": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -2038,15 +2003,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/asn1": {
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -2085,11 +2041,6 @@
             "engines": {
                 "node": ">=12.0.0"
             }
-        },
-        "node_modules/asn1js/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/assert": {
             "version": "1.5.1",
@@ -2312,9 +2263,9 @@
             }
         },
         "node_modules/bl": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.9.tgz",
-            "integrity": "sha512-Vh+M9HMfeTST9rkkQ1utRnOeABNcBO3i0dJMFkenCv7JIp76XWx8uQOGpaXyXVyenrLDZsdAHXbf0Cz18Eb0fw==",
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.10.tgz",
+            "integrity": "sha512-F14DFhDZfxtVm2FY0k9kG2lWAwzZkO9+jX3Ytuoy/V0E1/5LBuBzzQHXAjqpxXEDIpmTPZZf5GVIGPQcLxFpaA==",
             "dependencies": {
                 "buffer": "^6.0.3",
                 "inherits": "^2.0.4",
@@ -2353,9 +2304,9 @@
             }
         },
         "node_modules/bl/node_modules/readable-stream": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
-            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
@@ -2419,12 +2370,12 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/braces": {
@@ -2683,7 +2634,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
             "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-            "dev": true,
             "dependencies": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4"
@@ -2868,9 +2818,9 @@
             }
         },
         "node_modules/chai": {
-            "version": "4.3.10",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-            "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+            "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
             "dev": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
@@ -3128,9 +3078,9 @@
             }
         },
         "node_modules/coap/node_modules/readable-stream": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
-            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
@@ -4217,6 +4167,16 @@
                 "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
             }
         },
+        "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/eslint-plugin-import/node_modules/debug": {
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -4238,6 +4198,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eslint-plugin-import/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/eslint-plugin-import/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4248,9 +4220,9 @@
             }
         },
         "node_modules/eslint-plugin-n": {
-            "version": "16.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.5.0.tgz",
-            "integrity": "sha512-Hw02Bj1QrZIlKyj471Tb1jSReTl4ghIMHGuBGiMVmw+s0jOPbI4CBuYpGbZr+tdQ+VAvSK6FDSta3J4ib/SKHQ==",
+            "version": "16.6.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
+            "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -4258,6 +4230,7 @@
                 "builtins": "^5.0.1",
                 "eslint-plugin-es-x": "^7.5.0",
                 "get-tsconfig": "^4.7.0",
+                "globals": "^13.24.0",
                 "ignore": "^5.2.4",
                 "is-builtin-module": "^3.2.1",
                 "is-core-module": "^2.12.1",
@@ -4273,6 +4246,30 @@
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-n/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/eslint-plugin-node": {
@@ -4293,6 +4290,28 @@
             },
             "peerDependencies": {
                 "eslint": ">=5.16.0"
+            }
+        },
+        "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-node/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/eslint-plugin-node/node_modules/semver": {
@@ -4437,11 +4456,33 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/eslint/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/eslint/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/espree": {
             "version": "9.6.1",
@@ -4745,21 +4786,16 @@
             "dev": true
         },
         "node_modules/fast-unique-numbers": {
-            "version": "8.0.12",
-            "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.12.tgz",
-            "integrity": "sha512-Z4AJueNDnuC/sLxeQqrHP4zgqcBIeQQLbQ0hEx1a7m6Wf7ERrdAyR7CkGfoEFWm9Qla7dpLt0eWPyiO18gqj0A==",
+            "version": "8.0.13",
+            "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.13.tgz",
+            "integrity": "sha512-7OnTFAVPefgw2eBJ1xj2PGGR9FwYzSUso9decayHgCDX4sJkHLdcsYTytTg+tYv+wKF3U8gJuSBz2jJpQV4u/g==",
             "dependencies": {
-                "@babel/runtime": "^7.23.5",
+                "@babel/runtime": "^7.23.8",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.1.0"
             }
-        },
-        "node_modules/fast-unique-numbers/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/fastfall": {
             "version": "1.5.1",
@@ -4782,9 +4818,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-            "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
+            "integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -5282,6 +5318,26 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/globals": {
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -5528,50 +5584,9 @@
             }
         },
         "node_modules/help-me": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
-            "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
-            "dependencies": {
-                "glob": "^8.0.0",
-                "readable-stream": "^3.6.0"
-            }
-        },
-        "node_modules/help-me/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/help-me/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/help-me/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+            "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
         },
         "node_modules/hexy": {
             "version": "0.3.5",
@@ -5665,10 +5680,11 @@
             }
         },
         "node_modules/hyperid": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.1.1.tgz",
-            "integrity": "sha512-RveV33kIksycSf7HLkq1sHB5wW0OwuX8ot8MYnY++gaaPXGFfKpBncHrAWxdpuEeRlazUMGWefwP1w6o6GaumA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.2.0.tgz",
+            "integrity": "sha512-PdTtDo+Rmza9nEhTunaDSUKwbC69TIzLEpZUwiB6f+0oqmY0UPfhyHCPt6K1NQ4WFv5yJBTG5vELztVWP+nEVQ==",
             "dependencies": {
+                "buffer": "^5.2.1",
                 "uuid": "^8.3.2",
                 "uuid-parse": "^1.1.0"
             }
@@ -6303,9 +6319,9 @@
             }
         },
         "node_modules/jsonc-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
             "dev": true
         },
         "node_modules/jsonparse": {
@@ -6342,9 +6358,9 @@
             }
         },
         "node_modules/just-extend": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+            "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
             "dev": true
         },
         "node_modules/keyv": {
@@ -6657,14 +6673,18 @@
             "dev": true
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minimist": {
@@ -6692,15 +6712,15 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "node_modules/mlly": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
-            "integrity": "sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.5.0.tgz",
+            "integrity": "sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.10.0",
-                "pathe": "^1.1.1",
+                "acorn": "^8.11.3",
+                "pathe": "^1.1.2",
                 "pkg-types": "^1.0.3",
-                "ufo": "^1.3.0"
+                "ufo": "^1.3.2"
             }
         },
         "node_modules/mocha": {
@@ -6744,6 +6764,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mochajs"
+            }
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/mocha/node_modules/debug": {
@@ -6892,16 +6922,16 @@
             }
         },
         "node_modules/mqtt": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.3.3.tgz",
-            "integrity": "sha512-iy/9I81xnmYxENKL91hdiJ1LOkNYygCE0xCUtLeEo3BjQHraOky5gB/X3aPnvZ2fqlm1C0BhLmVcL6NRJ/U4tA==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.3.5.tgz",
+            "integrity": "sha512-xd7qt/LEM721U6yHQcqjlaAKXL1Fsqf/MXq6C2WPi/6OXK2jdSzL1eZ7ZUgjea7IY2yFLRWD5LNdT1mL0arPoA==",
             "dependencies": {
                 "@types/readable-stream": "^4.0.5",
                 "@types/ws": "^8.5.9",
                 "commist": "^3.2.0",
                 "concat-stream": "^2.0.0",
                 "debug": "^4.3.4",
-                "help-me": "^4.2.0",
+                "help-me": "^5.0.0",
                 "lru-cache": "^10.0.1",
                 "minimist": "^1.2.8",
                 "mqtt": "^5.2.0",
@@ -7034,9 +7064,9 @@
             }
         },
         "node_modules/mqtt/node_modules/lru-cache": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-            "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
             "engines": {
                 "node": "14 || >=16.14"
             }
@@ -7052,9 +7082,9 @@
             }
         },
         "node_modules/mqtt/node_modules/readable-stream": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
-            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
@@ -7067,9 +7097,9 @@
             }
         },
         "node_modules/mqtt/node_modules/ws": {
-            "version": "8.15.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
-            "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -7112,22 +7142,6 @@
                 "multicast-dns": "cli.js"
             }
         },
-        "node_modules/multimatch": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
-            "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/minimatch": "^3.0.3",
-                "array-differ": "^3.0.0",
-                "array-union": "^2.1.0",
-                "arrify": "^2.0.1",
-                "minimatch": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
@@ -7167,43 +7181,34 @@
             }
         },
         "node_modules/nise": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-            "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+            "version": "5.1.7",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
+            "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@sinonjs/text-encoding": "^0.7.1",
-                "just-extend": "^4.0.2",
-                "path-to-regexp": "^1.7.0"
+                "@sinonjs/commons": "^3.0.0",
+                "@sinonjs/fake-timers": "^11.2.2",
+                "@sinonjs/text-encoding": "^0.7.2",
+                "just-extend": "^6.2.0",
+                "path-to-regexp": "^6.2.1"
             }
         },
         "node_modules/nise/node_modules/@sinonjs/commons": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
         },
         "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+            "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
-            }
-        },
-        "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-            "dev": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
             }
         },
         "node_modules/node-abi": {
@@ -8799,18 +8804,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-            "dev": true,
-            "dependencies": {
-                "isarray": "0.0.1"
-            }
-        },
-        "node_modules/path-to-regexp/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
             "dev": true
         },
         "node_modules/path-type": {
@@ -8823,9 +8819,9 @@
             }
         },
         "node_modules/pathe": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
-            "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
             "dev": true
         },
         "node_modules/pathval": {
@@ -8857,6 +8853,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+        },
+        "node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -9016,39 +9018,27 @@
             }
         },
         "node_modules/pretty-quick": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.3.tgz",
-            "integrity": "sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.3.1.tgz",
+            "integrity": "sha512-3b36UXfYQ+IXXqex6mCca89jC8u0mYLqFAN5eTQKoXO6oCQYcIVYZEB/5AlBHI7JPYygReM2Vv6Vom/Gln7fBg==",
             "dev": true,
             "dependencies": {
-                "chalk": "^3.0.0",
-                "execa": "^4.0.0",
+                "execa": "^4.1.0",
                 "find-up": "^4.1.0",
-                "ignore": "^5.1.4",
-                "mri": "^1.1.5",
-                "multimatch": "^4.0.0"
+                "ignore": "^5.3.0",
+                "mri": "^1.2.0",
+                "picocolors": "^1.0.0",
+                "picomatch": "^3.0.1",
+                "tslib": "^2.6.2"
             },
             "bin": {
-                "pretty-quick": "bin/pretty-quick.js"
+                "pretty-quick": "dist/cli.js"
             },
             "engines": {
                 "node": ">=10.13"
             },
             "peerDependencies": {
-                "prettier": ">=2.0.0"
-            }
-        },
-        "node_modules/pretty-quick/node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
+                "prettier": "^2.0.0"
             }
         },
         "node_modules/pretty-quick/node_modules/find-up": {
@@ -9101,6 +9091,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/picomatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+            "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/process": {
@@ -9225,11 +9227,6 @@
             "dependencies": {
                 "tslib": "^2.6.1"
             }
-        },
-        "node_modules/pvtsutils/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/pvutils": {
             "version": "1.1.3",
@@ -9432,9 +9429,9 @@
         },
         "node_modules/readable-stream4": {
             "name": "readable-stream",
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
-            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
             "dev": true,
             "dependencies": {
                 "abort-controller": "^3.0.0",
@@ -9622,9 +9619,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
+            "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg=="
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
@@ -9685,13 +9682,13 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-            "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+            "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1",
+                "call-bind": "^1.0.5",
+                "get-intrinsic": "^1.2.2",
                 "has-symbols": "^1.0.3",
                 "isarray": "^2.0.5"
             },
@@ -9708,14 +9705,17 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/safe-regex-test": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+            "integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
+                "call-bind": "^1.0.5",
+                "get-intrinsic": "^1.2.2",
                 "is-regex": "^1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9863,14 +9863,15 @@
             "optional": true
         },
         "node_modules/set-function-length": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+            "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
             "dependencies": {
                 "define-data-property": "^1.1.1",
-                "get-intrinsic": "^1.2.1",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.2",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "has-property-descriptors": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10276,9 +10277,9 @@
             }
         },
         "node_modules/stream-shift": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+            "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
         },
         "node_modules/stream-splicer": {
             "version": "2.0.1",
@@ -10583,6 +10584,28 @@
                 "node": ">=8"
             }
         },
+        "node_modules/test-exclude/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/test-exclude/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -10792,9 +10815,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/tslint": {
             "version": "5.12.1",
@@ -10844,6 +10867,16 @@
             "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/tslint/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/tslint/node_modules/builtin-modules": {
@@ -10930,6 +10963,18 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/tslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/tslint/node_modules/semver": {
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -10951,6 +10996,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/tslint/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
         "node_modules/tsutils": {
             "version": "2.29.0",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
@@ -10963,6 +11014,12 @@
                 "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
             }
         },
+        "node_modules/tsutils/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
         "node_modules/tsyringe": {
             "version": "4.8.0",
             "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.8.0.tgz",
@@ -10973,6 +11030,11 @@
             "engines": {
                 "node": ">= 6.0.0"
             }
+        },
+        "node_modules/tsyringe/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/tty-browserify": {
             "version": "0.0.1",
@@ -11344,9 +11406,9 @@
             }
         },
         "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "version": "0.3.22",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+            "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -11409,29 +11471,24 @@
             }
         },
         "node_modules/web-streams-polyfill": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
+            "integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/webcrypto-core": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-            "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+            "version": "1.7.8",
+            "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.8.tgz",
+            "integrity": "sha512-eBR98r9nQXTqXt/yDRtInszPMjTaSAMJAFDg2AHsgrnczawT1asx9YNBX6k5p+MekbPF4+s/UJJrr88zsTqkSg==",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
                 "@peculiar/json-schema": "^1.1.12",
                 "asn1js": "^3.0.1",
-                "pvtsutils": "^1.3.2",
-                "tslib": "^2.4.0"
+                "pvtsutils": "^1.3.5",
+                "tslib": "^2.6.2"
             }
-        },
-        "node_modules/webcrypto-core/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
@@ -11526,50 +11583,35 @@
             }
         },
         "node_modules/worker-timers": {
-            "version": "7.0.80",
-            "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.80.tgz",
-            "integrity": "sha512-bYSAPNVR0Nrm7hTM3hQOxM3x+D9dXFG6kZ0BBqFyRu0BUGC5+DLLK5Sx281hCaNzOGMNcUMEaoeErx3Yuf7XIw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.1.1.tgz",
+            "integrity": "sha512-axtq83GwPqYwkQmQmei2abQ9cT7oSwmLw4lQCZ9VmMH9g4t4kuEF1Gw+tdnIJGHCiZ2QPDnr/+307bYx6tynLA==",
             "dependencies": {
-                "@babel/runtime": "^7.23.6",
+                "@babel/runtime": "^7.23.8",
                 "tslib": "^2.6.2",
-                "worker-timers-broker": "^6.0.100",
-                "worker-timers-worker": "^7.0.64"
+                "worker-timers-broker": "^6.1.1",
+                "worker-timers-worker": "^7.0.65"
             }
         },
         "node_modules/worker-timers-broker": {
-            "version": "6.0.100",
-            "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.0.100.tgz",
-            "integrity": "sha512-sXF1NpuT+FlJvONSbdZ6wNB15oNGg/P6PvCZDMHWmI6s7bHEb0zQ7cTnk9k+96/3pd8SpbXFuM0/HcHVc2alDQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.1.1.tgz",
+            "integrity": "sha512-CTlDnkXAewtYvw5gOwVIc6UuIPcNHJrqWxBMhZbCWOmadvl20nPs9beAsXlaTEwW3G2KBpuKiSgkhBkhl3mxDA==",
             "dependencies": {
-                "@babel/runtime": "^7.23.6",
-                "fast-unique-numbers": "^8.0.12",
+                "@babel/runtime": "^7.23.8",
+                "fast-unique-numbers": "^8.0.13",
                 "tslib": "^2.6.2",
-                "worker-timers-worker": "^7.0.64"
+                "worker-timers-worker": "^7.0.65"
             }
-        },
-        "node_modules/worker-timers-broker/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/worker-timers-worker": {
-            "version": "7.0.64",
-            "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.64.tgz",
-            "integrity": "sha512-bzBO7rVibSYFKu5NBYfjKBKHujaA/AJzJTuEEqaOGfzcTdJv15raDuGhtDoMjcNPvt3IylfLph6AK92kuifnXA==",
+            "version": "7.0.65",
+            "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.65.tgz",
+            "integrity": "sha512-Dl4nGONr8A8Fr+vQnH7Ee+o2iB480S1fBcyJYqnMyMwGRVyQZLZU+o91vbMvU1vHqiryRQmjXzzMYlh86wx+YQ==",
             "dependencies": {
-                "@babel/runtime": "^7.23.6",
+                "@babel/runtime": "^7.23.8",
                 "tslib": "^2.6.2"
             }
-        },
-        "node_modules/worker-timers-worker/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-        "node_modules/worker-timers/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/workerpool": {
             "version": "6.2.0",
@@ -11768,11 +11810,11 @@
         },
         "packages/binding-coap": {
             "name": "@node-wot/binding-coap",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "@types/node": "16.18.35",
                 "coap": "^1.3.0",
                 "multicast-dns": "^7.2.5",
@@ -11784,22 +11826,22 @@
         },
         "packages/binding-file": {
             "name": "@node-wot/binding-file",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12"
+                "@node-wot/core": "0.8.13"
             },
             "devDependencies": {
-                "@node-wot/td-tools": "0.8.12"
+                "@node-wot/td-tools": "0.8.13"
             }
         },
         "packages/binding-http": {
             "name": "@node-wot/binding-http",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "@types/eventsource": "1.1.10",
                 "accept-language-parser": "1.5.0",
                 "basic-auth": "2.0.1",
@@ -11824,22 +11866,22 @@
         },
         "packages/binding-mbus": {
             "name": "@node-wot/binding-mbus",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "node-mbus": "^2.1.0",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
             }
         },
         "packages/binding-modbus": {
             "name": "@node-wot/binding-modbus",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "modbus-serial": "8.0.3",
                 "rxjs": "5.5.11",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
@@ -11847,11 +11889,11 @@
         },
         "packages/binding-mqtt": {
             "name": "@node-wot/binding-mqtt",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "aedes": "^0.46.2",
                 "mqtt": "^5.3.2",
                 "rxjs": "5.5.11"
@@ -11859,11 +11901,11 @@
         },
         "packages/binding-netconf": {
             "name": "@node-wot/binding-netconf",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "@types/node-netconf": "npm:@types/netconf@^2.0.0",
                 "@types/url-parse": "^1.4.3",
                 "case-1.5.3": "npm:case@^1.5.3",
@@ -11873,11 +11915,11 @@
         },
         "packages/binding-opcua": {
             "name": "@node-wot/binding-opcua",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "ajv": "^8.11.0",
                 "ajv-formats": "^2.1.1",
                 "node-opcua": "2.113.0",
@@ -11911,19 +11953,19 @@
         },
         "packages/binding-websockets": {
             "name": "@node-wot/binding-websockets",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-http": "0.8.12",
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/binding-http": "0.8.13",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "slugify": "^1.4.5",
                 "ws": "^7.5.4"
             }
         },
         "packages/browser-bundle": {
             "name": "@node-wot/browser-bundle",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "events": "^2.1.0",
@@ -11931,26 +11973,26 @@
                 "resolve": "^1.1.7"
             },
             "devDependencies": {
-                "@node-wot/binding-http": "0.8.12",
-                "@node-wot/binding-websockets": "0.8.12",
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/binding-http": "0.8.13",
+                "@node-wot/binding-websockets": "0.8.13",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "browserify": "^17.0.0",
                 "readable-stream4": "npm:readable-stream@^4.0.0"
             }
         },
         "packages/cli": {
             "name": "@node-wot/cli",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.12",
-                "@node-wot/binding-file": "0.8.12",
-                "@node-wot/binding-http": "0.8.12",
-                "@node-wot/binding-mqtt": "0.8.12",
-                "@node-wot/binding-websockets": "0.8.12",
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/binding-coap": "0.8.13",
+                "@node-wot/binding-file": "0.8.13",
+                "@node-wot/binding-http": "0.8.13",
+                "@node-wot/binding-mqtt": "0.8.13",
+                "@node-wot/binding-websockets": "0.8.13",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "@types/lodash": "^4.14.199",
                 "ajv": "^8.11.0",
                 "commander": "^9.1.0",
@@ -11967,10 +12009,10 @@
         },
         "packages/core": {
             "name": "@node-wot/core",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/td-tools": "0.8.13",
                 "@petamoriken/float16": "^3.1.1",
                 "ajv": "^8.11.0",
                 "cbor": "^8.1.0",
@@ -11987,22 +12029,22 @@
         },
         "packages/examples": {
             "name": "@node-wot/examples",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.12",
-                "@node-wot/binding-file": "0.8.12",
-                "@node-wot/binding-http": "0.8.12",
-                "@node-wot/binding-mqtt": "0.8.12",
-                "@node-wot/binding-opcua": "0.8.12",
-                "@node-wot/core": "0.8.12",
-                "@node-wot/td-tools": "0.8.12",
+                "@node-wot/binding-coap": "0.8.13",
+                "@node-wot/binding-file": "0.8.13",
+                "@node-wot/binding-http": "0.8.13",
+                "@node-wot/binding-mqtt": "0.8.13",
+                "@node-wot/binding-opcua": "0.8.13",
+                "@node-wot/core": "0.8.13",
+                "@node-wot/td-tools": "0.8.13",
                 "rxjs": "5.5.11"
             }
         },
         "packages/td-tools": {
             "name": "@node-wot/td-tools",
-            "version": "0.8.12",
+            "version": "0.8.13",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "ajv": "^8.11.0",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-coap",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "CoAP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/coap.js",
     "types": "dist/coap.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "@types/node": "16.18.35",
         "coap": "^1.3.0",
         "multicast-dns": "^7.2.5",

--- a/packages/binding-file/package.json
+++ b/packages/binding-file/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-file",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "File client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,10 +14,10 @@
     "main": "dist/file.js",
     "types": "dist/file.d.ts",
     "devDependencies": {
-        "@node-wot/td-tools": "0.8.12"
+        "@node-wot/td-tools": "0.8.13"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.12"
+        "@node-wot/core": "0.8.13"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-http",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "HTTP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -28,8 +28,8 @@
         "timekeeper": "^2.2.0"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "@types/eventsource": "1.1.10",
         "accept-language-parser": "1.5.0",
         "basic-auth": "2.0.1",

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mbus",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "M-Bus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/mbus.js",
     "types": "dist/mbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "node-mbus": "^2.1.0",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     },

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-modbus",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "Modbus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "contributors": [
@@ -17,8 +17,8 @@
     "main": "dist/modbus.js",
     "types": "dist/modbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "modbus-serial": "8.0.3",
         "rxjs": "5.5.11",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mqtt",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "MQTT binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/mqtt.js",
     "types": "dist/mqtt.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "aedes": "^0.46.2",
         "mqtt": "^5.3.2",
         "rxjs": "5.5.11"

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-netconf",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "NetConf client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,8 +14,8 @@
     "main": "dist/netconf.js",
     "types": "dist/netconf.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "@types/node-netconf": "npm:@types/netconf@^2.0.0",
         "@types/url-parse": "^1.4.3",
         "case-1.5.3": "npm:case@^1.5.3",

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-opcua",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "opcua client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -18,8 +18,8 @@
         "should": "^13.2.3"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "node-opcua": "2.113.0",

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-websockets",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "WebSockets client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -15,9 +15,9 @@
     "types": "dist/ws.d.ts",
     "browser": "dist/ws-browser.js",
     "dependencies": {
-        "@node-wot/binding-http": "0.8.12",
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/binding-http": "0.8.13",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "slugify": "^1.4.5",
         "ws": "^7.5.4"
     },

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/browser-bundle",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "A node-wot bundle that can run in a web browser",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -13,10 +13,10 @@
     ],
     "main": "dist/wot-bundle.min.js",
     "devDependencies": {
-        "@node-wot/binding-http": "0.8.12",
-        "@node-wot/binding-websockets": "0.8.12",
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/binding-http": "0.8.13",
+        "@node-wot/binding-websockets": "0.8.13",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "browserify": "^17.0.0",
         "readable-stream4": "npm:readable-stream@^4.0.0"
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/cli",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "servient command line interface",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -20,13 +20,13 @@
         "ts-node": "10.9.1"
     },
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.12",
-        "@node-wot/binding-file": "0.8.12",
-        "@node-wot/binding-http": "0.8.12",
-        "@node-wot/binding-mqtt": "0.8.12",
-        "@node-wot/binding-websockets": "0.8.12",
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/binding-coap": "0.8.13",
+        "@node-wot/binding-file": "0.8.13",
+        "@node-wot/binding-http": "0.8.13",
+        "@node-wot/binding-mqtt": "0.8.13",
+        "@node-wot/binding-websockets": "0.8.13",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "@types/lodash": "^4.14.199",
         "ajv": "^8.11.0",
         "commander": "^9.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/core",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "W3C Web of Things (WoT) Servient framework",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -20,7 +20,7 @@
         "@types/uuid": "^8.3.1"
     },
     "dependencies": {
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/td-tools": "0.8.13",
         "@petamoriken/float16": "^3.1.1",
         "ajv": "^8.11.0",
         "cbor": "^8.1.0",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,19 +1,19 @@
 {
     "name": "@node-wot/examples",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "private": true,
     "description": "Examples for node-wot (not published)",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
     "repository": "https://github.com/eclipse-thingweb/node-wot/tree/master/packages/examples",
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.12",
-        "@node-wot/binding-file": "0.8.12",
-        "@node-wot/binding-http": "0.8.12",
-        "@node-wot/binding-mqtt": "0.8.12",
-        "@node-wot/binding-opcua": "0.8.12",
-        "@node-wot/core": "0.8.12",
-        "@node-wot/td-tools": "0.8.12",
+        "@node-wot/binding-coap": "0.8.13",
+        "@node-wot/binding-file": "0.8.13",
+        "@node-wot/binding-http": "0.8.13",
+        "@node-wot/binding-mqtt": "0.8.13",
+        "@node-wot/binding-opcua": "0.8.13",
+        "@node-wot/core": "0.8.13",
+        "@node-wot/td-tools": "0.8.13",
         "rxjs": "5.5.11"
     },
     "scripts": {

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/td-tools",
-    "version": "0.8.12",
+    "version": "0.8.13",
     "description": "W3C Web of Things (WoT) Thing Description parser, serializer, and other tools",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",


### PR DESCRIPTION
FYI: Every time we update the node-wot package versions we also newly create `package-lock.json` to update dependencies.
Hence one can see many changes for `package-lock.json` ...