### PR TITLE
Events for simple coffee machine

### DIFF
--- a/examples/quickstart/simple-coffee-machine.js
+++ b/examples/quickstart/simple-coffee-machine.js
@@ -25,9 +25,9 @@ servient.addServer(
     })
 );
 core_1.Helpers.setStaticAddress("plugfest.thingweb.io"); // comment this out if you are testing locally
-let waterAmount = 1000;
-let beansAmount = 1000;
-let milkAmount = 1000;
+let waterAmount = 28;
+let beansAmount = 28;
+let milkAmount = 28;
 // promisify timeout since it does not return a promise
 function timeout(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -78,6 +78,13 @@ servient.start().then((WoT) => {
                 },
             },
         },
+        events: {
+            resourceEmpty: {
+                data: {
+                    enum: ["water", "beans", "milk"],
+                },
+            },
+        },
     })
         .then((thing) => {
             console.log("Produced " + thing.getThingDescription().title);
@@ -99,6 +106,14 @@ servient.start().then((WoT) => {
                         waterAmount = waterAmount - 10;
                         beansAmount = beansAmount - 10;
                         thing.emitPropertyChange("resources");
+                        if (waterAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "water");
+                            return undefined;
+                        }
+                        if (beansAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "beans");
+                            return undefined;
+                        }
                         return undefined;
                     }
                 } else if (coffeeType === "cappuccino") {
@@ -110,6 +125,17 @@ servient.start().then((WoT) => {
                         beansAmount = beansAmount - 20;
                         milkAmount = milkAmount - 10;
                         thing.emitPropertyChange("resources");
+                        if (waterAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "water");
+                            return undefined;
+                        }
+                        if (beansAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "beans");
+                            return undefined;
+                        }
+                        if (milkAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "milk");
+                        }
                         return undefined;
                     }
                 } else if (coffeeType === "americano") {
@@ -120,6 +146,14 @@ servient.start().then((WoT) => {
                         waterAmount = waterAmount - 30;
                         beansAmount = beansAmount - 10;
                         thing.emitPropertyChange("resources");
+                        if (waterAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "water");
+                            return undefined;
+                        }
+                        if (beansAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "beans");
+                            return undefined;
+                        }
                         return undefined;
                     }
                 } else {

--- a/examples/quickstart/simple-coffee-machine.js
+++ b/examples/quickstart/simple-coffee-machine.js
@@ -125,10 +125,8 @@ servient.start().then((WoT) => {
                         }
                         if (resourceEvent.length > 0) {
                             thing.emitEvent("resourceEmpty", resourceEvent);
-                            return undefined;
-                        } else {
-                            return undefined;
                         }
+                        return undefined;
                     }
                 } else if (coffeeType === "cappuccino") {
                     if (waterAmount <= 20 || beansAmount <= 25 || milkAmount <= 15) {
@@ -151,10 +149,8 @@ servient.start().then((WoT) => {
                         }
                         if (resourceEvent.length > 0) {
                             thing.emitEvent("resourceEmpty", resourceEvent);
-                            return undefined;
-                        } else {
-                            return undefined;
                         }
+                        return undefined;
                     }
                 } else if (coffeeType === "americano") {
                     if (waterAmount <= 35 || beansAmount <= 10) {
@@ -173,10 +169,8 @@ servient.start().then((WoT) => {
                         }
                         if (resourceEvent.length > 0) {
                             thing.emitEvent("resourceEmpty", resourceEvent);
-                            return undefined;
-                        } else {
-                            return undefined;
                         }
+                        return undefined;
                     }
                 } else {
                     throw new Error("Wrong coffee input");

--- a/examples/quickstart/simple-coffee-machine.js
+++ b/examples/quickstart/simple-coffee-machine.js
@@ -179,15 +179,12 @@ servient.start().then((WoT) => {
             thing.setActionHandler("refill", async (params, options) => {
                 const selectedResource = await params.value();
                 console.info("received refill order of ", selectedResource);
-                // @ts-expect-error: Property doesn't exist error
                 if (selectedResource.indexOf("water") !== -1) {
                     waterAmount = 1000;
                 }
-                // @ts-expect-error: Property doesn't exist error
                 if (selectedResource.indexOf("beans") !== -1) {
                     beansAmount = 1000;
                 }
-                // @ts-expect-error: Property doesn't exist error
                 if (selectedResource.indexOf("milk") !== -1) {
                     milkAmount = 1000;
                 }

--- a/packages/examples/src/quickstart/simple-coffee-machine.ts
+++ b/packages/examples/src/quickstart/simple-coffee-machine.ts
@@ -115,7 +115,7 @@ servient.start().then((WoT) => {
                         beansAmount = beansAmount - 10;
                         thing.emitPropertyChange("resources");
                         if (waterAmount <= 10) {
-                            thing.emitEvent("resourceEmpty","water")
+                            thing.emitEvent("resourceEmpty", "water");
                             return undefined;
                         }
                         if (beansAmount <= 10) {

--- a/packages/examples/src/quickstart/simple-coffee-machine.ts
+++ b/packages/examples/src/quickstart/simple-coffee-machine.ts
@@ -133,10 +133,8 @@ servient.start().then((WoT) => {
                         }
                         if (resourceEvent.length > 0) {
                             thing.emitEvent("resourceEmpty", resourceEvent);
-                            return undefined;
-                        } else {
-                            return undefined;
                         }
+                        return undefined;
                     }
                 } else if (coffeeType === "cappuccino") {
                     if (waterAmount <= 20 || beansAmount <= 25 || milkAmount <= 15) {
@@ -159,10 +157,8 @@ servient.start().then((WoT) => {
                         }
                         if (resourceEvent.length > 0) {
                             thing.emitEvent("resourceEmpty", resourceEvent);
-                            return undefined;
-                        } else {
-                            return undefined;
                         }
+                        return undefined;
                     }
                 } else if (coffeeType === "americano") {
                     if (waterAmount <= 35 || beansAmount <= 10) {
@@ -181,10 +177,8 @@ servient.start().then((WoT) => {
                         }
                         if (resourceEvent.length > 0) {
                             thing.emitEvent("resourceEmpty", resourceEvent);
-                            return undefined;
-                        } else {
-                            return undefined;
                         }
+                        return undefined;
                     }
                 } else {
                     throw new Error("Wrong coffee input");

--- a/packages/examples/src/quickstart/simple-coffee-machine.ts
+++ b/packages/examples/src/quickstart/simple-coffee-machine.ts
@@ -24,7 +24,7 @@ const servient = new Servient();
 
 // const staticAddress = "plugfest.thingweb.io";
 const staticAddress = "localhost"; // use this for testing locally
-const httpPort = 8081
+const httpPort = 8081;
 servient.addServer(
     new HttpServer({
         port: httpPort,
@@ -124,14 +124,14 @@ servient.start().then((WoT) => {
                         waterAmount = waterAmount - 10;
                         beansAmount = beansAmount - 10;
                         thing.emitPropertyChange("resources");
-                        const resourceEvent: Array <string> = [];
+                        const resourceEvent: Array<string> = [];
                         if (waterAmount <= 10) {
-                            resourceEvent.push("water")
+                            resourceEvent.push("water");
                         }
                         if (beansAmount <= 10) {
                             resourceEvent.push("beans");
                         }
-                        if (resourceEvent.length>0){
+                        if (resourceEvent.length > 0) {
                             thing.emitEvent("resourceEmpty", resourceEvent);
                             return undefined;
                         } else {

--- a/packages/examples/src/quickstart/simple-coffee-machine.ts
+++ b/packages/examples/src/quickstart/simple-coffee-machine.ts
@@ -186,17 +186,14 @@ servient.start().then((WoT) => {
             });
 
             thing.setActionHandler("refill", async (params, options) => {
-                const selectedResource = await params.value();
+                const selectedResource = (await params.value()) as Array<"water" | "beans" | "milk">;
                 console.info("received refill order of ", selectedResource);
-                // @ts-expect-error: Property doesn't exist error
                 if (selectedResource!.indexOf("water") !== -1) {
                     waterAmount = 1000;
                 }
-                // @ts-expect-error: Property doesn't exist error
                 if (selectedResource!.indexOf("beans") !== -1) {
                     beansAmount = 1000;
                 }
-                // @ts-expect-error: Property doesn't exist error
                 if (selectedResource!.indexOf("milk") !== -1) {
                     milkAmount = 1000;
                 }

--- a/packages/examples/src/quickstart/simple-coffee-machine.ts
+++ b/packages/examples/src/quickstart/simple-coffee-machine.ts
@@ -84,6 +84,13 @@ servient.start().then((WoT) => {
                 },
             },
         },
+        events: {
+            resourceEmpty: {
+                data: {
+                    enum: ["water", "beans", "milk"],
+                },
+            },
+        },
     })
         .then((thing) => {
             console.log("Produced " + thing.getThingDescription().title);
@@ -107,6 +114,14 @@ servient.start().then((WoT) => {
                         waterAmount = waterAmount - 10;
                         beansAmount = beansAmount - 10;
                         thing.emitPropertyChange("resources");
+                        if (waterAmount <= 10) {
+                            thing.emitEvent("resourceEmpty","water")
+                            return undefined;
+                        }
+                        if (beansAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "beans");
+                            return undefined;
+                        }
                         return undefined;
                     }
                 } else if (coffeeType === "cappuccino") {
@@ -118,6 +133,17 @@ servient.start().then((WoT) => {
                         beansAmount = beansAmount - 20;
                         milkAmount = milkAmount - 10;
                         thing.emitPropertyChange("resources");
+                        if (waterAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "water");
+                            return undefined;
+                        }
+                        if (beansAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "beans");
+                            return undefined;
+                        }
+                        if (milkAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "milk");
+                        }
                         return undefined;
                     }
                 } else if (coffeeType === "americano") {
@@ -128,6 +154,14 @@ servient.start().then((WoT) => {
                         waterAmount = waterAmount - 30;
                         beansAmount = beansAmount - 10;
                         thing.emitPropertyChange("resources");
+                        if (waterAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "water");
+                            return undefined;
+                        }
+                        if (beansAmount <= 10) {
+                            thing.emitEvent("resourceEmpty", "beans");
+                            return undefined;
+                        }
                         return undefined;
                     }
                 } else {


### PR DESCRIPTION
This is adding events to the simple coffee machine. With @relu91 we will use this in the nodejs conf presentation. There are those return statements added after event emissions since without doing that I was getting an event emission with data `"water""beans"`. Some race condition maybe? It is not an elegant solution but if that is indeed an issue with node-wot (and not my oversight), I would propose to go with this PR and open an issue about it.