### PR TITLE
fix(binding-http): fill security scheme when baseURI defined

### DIFF
--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -276,6 +276,11 @@ export default class HttpServer implements ProtocolServer {
         if (this.getPort() !== -1) {
             debug(`HttpServer on port ${this.getPort()} exposes '${thing.title}' as unique '/${urlPath}'`);
             this.things.set(urlPath, thing);
+
+            if (this.scheme === "http" && Object.keys(thing.securityDefinitions).length !== 0) {
+                warn(`HTTP Server will attempt to use your security schemes even if you are not using HTTPS.`);
+            }
+
             this.fillSecurityScheme(thing);
 
             if (this.baseUri !== undefined) {
@@ -291,10 +296,6 @@ export default class HttpServer implements ProtocolServer {
                     this.addEndpoint(thing, tdTemplate, base);
                     // media types
                 } // addresses
-
-                if (this.scheme === "http" && Object.keys(thing.securityDefinitions).length !== 0) {
-                    warn(`HTTP Server will attempt to use your security schemes even if you are not using HTTPS.`);
-                }
             }
         }
     }

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -294,8 +294,7 @@ export default class HttpServer implements ProtocolServer {
                         this.scheme + "://" + address + ":" + this.getPort() + "/" + encodeURIComponent(urlPath);
 
                     this.addEndpoint(thing, tdTemplate, base);
-                    // media types
-                } // addresses
+                }
             }
         }
     }

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -276,6 +276,7 @@ export default class HttpServer implements ProtocolServer {
         if (this.getPort() !== -1) {
             debug(`HttpServer on port ${this.getPort()} exposes '${thing.title}' as unique '/${urlPath}'`);
             this.things.set(urlPath, thing);
+            this.fillSecurityScheme(thing);
 
             if (this.baseUri !== undefined) {
                 const base: string = this.baseUri.concat("/", encodeURIComponent(urlPath));
@@ -294,8 +295,6 @@ export default class HttpServer implements ProtocolServer {
                 if (this.scheme === "http" && Object.keys(thing.securityDefinitions).length !== 0) {
                     warn(`HTTP Server will attempt to use your security schemes even if you are not using HTTPS.`);
                 }
-
-                this.fillSecurityScheme(thing);
             }
         }
     }

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -438,6 +438,21 @@ class HttpServerTest {
         expect(testThing.securityDefinitions.bearer).not.eql(undefined);
     }
 
+    @test async "should fill default security scheme even with baseURI defined"() {
+        const httpServer = new HttpServer({
+            port: port2,
+            baseUri: "https://example.com",
+        });
+        await httpServer.start(new Servient());
+        const testThing = new ExposedThing(new Servient());
+        testThing.title = "Test";
+        httpServer.expose(testThing);
+        await httpServer.stop();
+
+        expect(testThing.securityDefinitions.nosec).to.not.eql(undefined);
+        expect(testThing.securityDefinitions.nosec.scheme).to.be.eql("nosec");
+    }
+
     @test async "should not accept an unsupported scheme"() {
         debug("START SHOULD");
         const httpServer = new HttpServer({


### PR DESCRIPTION
Found a bug when exposing things with a `baseURI` defined. I added a failing test to verify the correct behavior and avoid regression. 