### PR TITLE
[octetsream-codec] fix serialization and deserialization of nested objects

### DIFF
--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -215,7 +215,7 @@ export default class OctetstreamCodec implements ContentCodec {
         for (const propertyName of sortedProperties) {
             const propertySchema = schema.properties[propertyName];
             const length = bytes.length.toString();
-            result[propertyName] = this.bytesToValue(bytes, propertySchema, {...parameters, length});
+            result[propertyName] = this.bytesToValue(bytes, propertySchema, { ...parameters, length });
         }
         return result;
     }

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -543,8 +543,18 @@ export default class OctetstreamCodec implements ContentCodec {
             throw new Error("Missing 'length' parameter necessary for write");
         }
 
+        const length = parseInt(parameters.length);
         const offset = schema["ex:bitOffset"] !== undefined ? parseInt(schema["ex:bitOffset"]) : 0;
-        result = result ?? Buffer.alloc(parseInt(parameters.length));
+
+        if (isNaN(offset) || offset < 0) {
+            throw new Error("ex:bitOffset must be a non-negative number");
+        }
+
+        if (offset > length * 8) {
+            throw new Error(`ex:bitOffset ${offset} exceeds length ${length}`);
+        }
+
+        result = result ?? Buffer.alloc(length);
         for (const propertyName in schema.properties) {
             if (Object.hasOwnProperty.call(value, propertyName) === false) {
                 throw new Error(`Missing property '${propertyName}'`);

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -559,8 +559,8 @@ export default class OctetstreamCodec implements ContentCodec {
         result = result ?? Buffer.alloc(parseInt(parameters.length));
         for (const propertyName in schema.properties) {
             if (Object.hasOwnProperty.call(value, propertyName) === false) {
-                                    throw new Error(`Missing property '${propertyName}'`);
-                            }
+                throw new Error(`Missing property '${propertyName}'`);
+            }
             const propertySchema = schema.properties[propertyName];
             const propertyValue = value[propertyName];
             const propertyOffset = parseInt(propertySchema["ex:bitOffset"]);

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -214,20 +214,8 @@ export default class OctetstreamCodec implements ContentCodec {
         const sortedProperties = Object.getOwnPropertyNames(schema.properties);
         for (const propertyName of sortedProperties) {
             const propertySchema = schema.properties[propertyName];
-            if (propertySchema.type === "object") {
-                const bitLength = parseInt(propertySchema["ex:bitLength"]);
-                const bitOffset =
-                    propertySchema["ex:bitOffset"] !== undefined ? parseInt(propertySchema["ex:bitOffset"]) : 0;
-                const length = isNaN(bitLength) ? bytes.length : Math.ceil(bitLength / 8);
-                const buf = Buffer.alloc(length);
-                this.copyBits(bytes, bitOffset, buf, 0, length * 8);
-                result[propertyName] = this.objectToValue(buf, propertySchema, {
-                    ...parameters,
-                    length: length.toString(),
-                });
-            } else {
-                result[propertyName] = this.bytesToValue(bytes, propertySchema, parameters);
-            }
+            const length = bytes.length.toString();
+            result[propertyName] = this.bytesToValue(bytes, propertySchema, {...parameters, length});
         }
         return result;
     }
@@ -567,9 +555,7 @@ export default class OctetstreamCodec implements ContentCodec {
             const propertyLength = parseInt(propertySchema["ex:bitLength"]);
             let buf: Buffer;
             if (propertySchema.type === "object") {
-                const length = Math.ceil(propertyLength / 8).toString();
-
-                buf = this.valueToObject(propertyValue, propertySchema, { ...parameters, length }, result);
+                buf = this.valueToObject(propertyValue, propertySchema, parameters, result);
             } else {
                 buf = this.valueToBytes(propertyValue, propertySchema, parameters);
             }

--- a/packages/core/src/codecs/octetstream-codec.ts
+++ b/packages/core/src/codecs/octetstream-codec.ts
@@ -59,14 +59,41 @@ export default class OctetstreamCodec implements ContentCodec {
         debug("OctetstreamCodec parsing", bytes);
         debug("Parameters", parameters);
 
-        const bigEndian = !(parameters.byteSeq?.includes(Endianness.LITTLE_ENDIAN) === true); // default to big endian
-        let signed = parameters.signed !== "false"; // default to signed
-        const offset = schema?.["ex:bitOffset"] !== undefined ? parseInt(schema["ex:bitOffset"]) : 0;
-        if (parameters.length != null && parseInt(parameters.length) !== bytes.length) {
-            throw new Error("Lengths do not match, required: " + parameters.length + " provided: " + bytes.length);
+        const length =
+            parameters.length != null
+                ? parseInt(parameters.length)
+                : (warn("Missing 'length' parameter necessary for write. I'll do my best"), undefined);
+
+        if (length !== undefined) {
+            if (isNaN(length) || length < 0) {
+                throw new Error("'length' parameter must be a non-negative number");
+            }
+            if (length !== bytes.length) {
+                throw new Error(`Lengths do not match, required: ${length} provided: ${bytes.length}`);
+            }
         }
-        let bitLength: number =
-            schema?.["ex:bitLength"] !== undefined ? parseInt(schema["ex:bitLength"]) : bytes.length * 8;
+
+        let signed = true; // default to signed
+        if (parameters.signed !== undefined) {
+            if (parameters.signed !== "true" && parameters.signed !== "false") {
+                throw new Error("'signed' parameter must be 'true' or 'false'");
+            }
+            signed = parameters.signed === "true";
+        }
+
+        let bitLength = schema?.["ex:bitLength"] !== undefined ? parseInt(schema["ex:bitLength"]) : bytes.length * 8;
+
+        if (isNaN(bitLength) || bitLength < 0) {
+            throw new Error("'ex:bitLength' must be a non-negative number");
+        }
+
+        const offset = schema?.["ex:bitOffset"] !== undefined ? parseInt(schema["ex:bitOffset"]) : 0;
+
+        if (isNaN(offset) || offset < 0) {
+            throw new Error("'ex:bitOffset' must be a non-negative number");
+        }
+
+        const bigEndian = !(parameters.byteSeq?.includes(Endianness.LITTLE_ENDIAN) === true); // default to big endian
         let dataType: string = schema?.type;
 
         if (!dataType) {
@@ -223,16 +250,38 @@ export default class OctetstreamCodec implements ContentCodec {
     valueToBytes(value: unknown, schema?: DataSchema, parameters: { [key: string]: string | undefined } = {}): Buffer {
         debug(`OctetstreamCodec serializing '${value}'`);
 
-        if (parameters.length == null) {
-            warn("Missing 'length' parameter necessary for write. I'll do my best");
+        const bigEndian = !(parameters.byteSeq?.includes(Endianness.LITTLE_ENDIAN) === true); // default to big endian
+
+        let signed = true; // default to true
+
+        if (parameters.signed !== undefined) {
+            if (parameters.signed !== "true" && parameters.signed !== "false") {
+                throw new Error("'signed' parameter must be 'true' or 'false'");
+            }
+            signed = parameters.signed === "true";
         }
 
-        const bigEndian = !(parameters.byteSeq?.includes(Endianness.LITTLE_ENDIAN) === true); // default to big endian
-        let signed = parameters.signed !== "false"; // default to signed
-        // byte length of the buffer to be returned
-        let length = parameters.length != null ? parseInt(parameters.length) : undefined;
+        let length =
+            parameters.length != null
+                ? parseInt(parameters.length)
+                : (warn("Missing 'length' parameter necessary for write. I'll do my best"), undefined);
+
+        if (length !== undefined && (isNaN(length) || length < 0)) {
+            throw new Error("'length' parameter must be a non-negative number");
+        }
+
         let bitLength = schema?.["ex:bitLength"] !== undefined ? parseInt(schema["ex:bitLength"]) : undefined;
+
+        if (bitLength !== undefined && (isNaN(bitLength) || bitLength < 0)) {
+            throw new Error("'ex:bitLength' must be a non-negative number");
+        }
+
         const offset = schema?.["ex:bitOffset"] !== undefined ? parseInt(schema["ex:bitOffset"]) : 0;
+
+        if (isNaN(offset) || offset < 0) {
+            throw new Error("'ex:bitOffset' must be a non-negative number");
+        }
+
         let dataType: string = schema?.type ?? undefined;
 
         if (value === undefined) {
@@ -547,11 +596,11 @@ export default class OctetstreamCodec implements ContentCodec {
         const offset = schema["ex:bitOffset"] !== undefined ? parseInt(schema["ex:bitOffset"]) : 0;
 
         if (isNaN(offset) || offset < 0) {
-            throw new Error("ex:bitOffset must be a non-negative number");
+            throw new Error("'ex:bitOffset' must be a non-negative number");
         }
 
         if (offset > length * 8) {
-            throw new Error(`ex:bitOffset ${offset} exceeds length ${length}`);
+            throw new Error(`'ex:bitOffset' ${offset} exceeds 'length' ${length}`);
         }
 
         result = result ?? Buffer.alloc(length);

--- a/packages/core/test/ContentSerdesTest.ts
+++ b/packages/core/test/ContentSerdesTest.ts
@@ -444,6 +444,59 @@ class SerdesOctetTests {
                 },
             }
         );
+
+        checkStreamToValue(
+            [0x0e, 0x10, 0x10, 0x10, 0x0e],
+            {
+                flags1: { flag1: false, flag2: true },
+                flags2: { flag1: true, flag2: false },
+            },
+            "object",
+            {
+                type: "object",
+                properties: {
+                    flags1: {
+                        type: "object",
+                        "ex:bitOffset": 0,
+                        "ex:bitLength": 8,
+                        properties: {
+                            flag1: {
+                                type: "boolean",
+                                title: "Bit 1",
+                                "ex:bitOffset": 3,
+                                "ex:bitLength": 1,
+                            },
+                            flag2: {
+                                type: "boolean",
+                                title: "Bit 2",
+                                "ex:bitOffset": 4,
+                                "ex:bitLength": 1,
+                            },
+                        },
+                    },
+                    flags2: {
+                        type: "object",
+                        "ex:bitOffset": 8,
+                        "ex:bitLength": 8,
+                        properties: {
+                            flag1: {
+                                type: "boolean",
+                                title: "Bit 1",
+                                "ex:bitOffset": 3,
+                                "ex:bitLength": 1,
+                            },
+                            flag2: {
+                                type: "boolean",
+                                title: "Bit 2",
+                                "ex:bitOffset": 4,
+                                "ex:bitLength": 1,
+                            },
+                        },
+                    },
+                },
+            },
+            { length: "5" }
+        );
     }
 
     @test async "OctetStream to value should throw"() {
@@ -515,7 +568,7 @@ class SerdesOctetTests {
         ).to.throw(Error, "Missing schema for object");
         expect(() =>
             ContentSerdes.contentToValue(
-                { type: "application/octet-stream", body: Buffer.from([0x36, 0x30]) },
+                { type: "application/octet-stream;length=2", body: Buffer.from([0x36, 0x30]) },
                 {
                     type: "object",
                     properties: {
@@ -763,6 +816,39 @@ class SerdesOctetTests {
         );
         body = await content.toBuffer();
         expect(body).to.deep.equal(Buffer.from([0xc0]));
+
+        content = ContentSerdes.valueToContent(
+            {
+                flags1: { flag1: false, flag2: true },
+                flags2: { flag1: true, flag2: false },
+            },
+            {
+                type: "object",
+                properties: {
+                    flags1: {
+                        type: "object",
+                        properties: {
+                            flag1: { type: "boolean", "ex:bitOffset": 3, "ex:bitLength": 1 },
+                            flag2: { type: "boolean", "ex:bitOffset": 4, "ex:bitLength": 1 },
+                        },
+                        "ex:bitLength": 8,
+                    },
+                    flags2: {
+                        type: "object",
+                        properties: {
+                            flag1: { type: "boolean", "ex:bitOffset": 3, "ex:bitLength": 1 },
+                            flag2: { type: "boolean", "ex:bitOffset": 4, "ex:bitLength": 1 },
+                        },
+                        "ex:bitOffset": 8,
+                        "ex:bitLength": 8,
+                    },
+                },
+                "ex:bitLength": 16,
+            },
+            "application/octet-stream;length=2;"
+        );
+        body = await content.toBuffer();
+        expect(body).to.deep.equal(Buffer.from([0x08, 0x10]));
     }
 
     @test "value to OctetStream should throw"() {

--- a/packages/core/test/ContentSerdesTest.ts
+++ b/packages/core/test/ContentSerdesTest.ts
@@ -568,7 +568,7 @@ class SerdesOctetTests {
         ).to.throw(Error, "Missing schema for object");
         expect(() =>
             ContentSerdes.contentToValue(
-                { type: "application/octet-stream;length=2", body: Buffer.from([0x36, 0x30]) },
+                { type: "application/octet-stream", body: Buffer.from([0x36, 0x30]) },
                 {
                     type: "object",
                     properties: {

--- a/packages/core/test/ContentSerdesTest.ts
+++ b/packages/core/test/ContentSerdesTest.ts
@@ -584,6 +584,55 @@ class SerdesOctetTests {
                 { type: "uint8" }
             )
         ).to.throw(Error, "Type is unsigned but 'signed' is true");
+
+        expect(() =>
+            ContentSerdes.contentToValue(
+                { type: `application/octet-stream;length=test`, body: Buffer.from([0x36]) },
+                { type: "integer" }
+            )
+        ).to.throw(Error, "'length' parameter must be a non-negative number");
+
+        expect(() =>
+            ContentSerdes.contentToValue(
+                { type: `application/octet-stream;length=-1`, body: Buffer.from([0x36]) },
+                { type: "integer" }
+            )
+        ).to.throw(Error, "'length' parameter must be a non-negative number");
+
+        expect(() =>
+            ContentSerdes.contentToValue(
+                { type: `application/octet-stream;signed=invalid`, body: Buffer.from([0x36]) },
+                { type: "integer" }
+            )
+        ).to.throw(Error, "'signed' parameter must be 'true' or 'false'");
+
+        expect(() =>
+            ContentSerdes.contentToValue(
+                { type: `application/octet-stream`, body: Buffer.from([0x36]) },
+                { type: "integer", "ex:bitOffset": "invalid" }
+            )
+        ).to.throw(Error, "'ex:bitOffset' must be a non-negative number");
+
+        expect(() =>
+            ContentSerdes.contentToValue(
+                { type: `application/octet-stream`, body: Buffer.from([0x36]) },
+                { type: "integer", "ex:bitOffset": -1 }
+            )
+        ).to.throw(Error, "'ex:bitOffset' must be a non-negative number");
+
+        expect(() =>
+            ContentSerdes.contentToValue(
+                { type: `application/octet-stream`, body: Buffer.from([0x36]) },
+                { type: "integer", "ex:bitLength": "invalid" }
+            )
+        ).to.throw(Error, "'ex:bitLength' must be a non-negative number");
+
+        expect(() =>
+            ContentSerdes.contentToValue(
+                { type: `application/octet-stream`, body: Buffer.from([0x36]) },
+                { type: "integer", "ex:bitLength": -1 }
+            )
+        ).to.throw(Error, "'ex:bitLength' must be a non-negative number");
     }
 
     @test async "value to OctetStream"() {
@@ -937,6 +986,29 @@ class SerdesOctetTests {
             Error,
             "Missing 'type' property in schema"
         );
+        expect(() => ContentSerdes.valueToContent(10, { type: "int8" }, "application/octet-stream;signed=8")).to.throw(
+            Error,
+            "'signed' parameter must be 'true' or 'false'"
+        );
+        expect(() =>
+            ContentSerdes.valueToContent(10, { type: "int8" }, "application/octet-stream;length=-1;")
+        ).to.throw(Error, "'length' parameter must be a non-negative number");
+        expect(() => ContentSerdes.valueToContent(10, { type: "int8" }, "application/octet-stream;length=x;")).to.throw(
+            Error,
+            "'length' parameter must be a non-negative number"
+        );
+        expect(() =>
+            ContentSerdes.valueToContent(10, { type: "integer", "ex:bitOffset": -16 }, "application/octet-stream")
+        ).to.throw(Error, "'ex:bitOffset' must be a non-negative number");
+        expect(() =>
+            ContentSerdes.valueToContent(10, { type: "integer", "ex:bitOffset": "foo" }, "application/octet-stream")
+        ).to.throw(Error, "'ex:bitOffset' must be a non-negative number");
+        expect(() =>
+            ContentSerdes.valueToContent(10, { type: "integer", "ex:bitLength": -8 }, "application/octet-stream")
+        ).to.throw(Error, "'ex:bitLength' must be a non-negative number");
+        expect(() =>
+            ContentSerdes.valueToContent(10, { type: "integer", "ex:bitLength": "foo" }, "application/octet-stream")
+        ).to.throw(Error, "'ex:bitLength' must be a non-negative number");
     }
 }
 


### PR DESCRIPTION
After using the octetstream codec's object serialization and deserialization for a while now, I discovered a bug when handling nested objects:

When serializing values, the object's bit-offset would not be passed on to the nested serialization call.

For example (added to the tests in this PR, too):
Serializing an object like
``` json
{
    "flags1": { "flag1": false, "flag2": true },
    "flags2": { "flag1": true, "flag2": false },
}
```
with the following DataSchema
```json
{
    "type": "object",
    "properties": {
        "flags1": {
            "type": "object",
            "properties": {
                "flag1": { "type": "boolean", "ex:bitOffset": 3, "ex:bitLength": 1 },
                "flag2": { "type": "boolean", "ex:bitOffset": 4, "ex:bitLength": 1 },
            },
            "ex:bitLength": 8,
        },
        "flags2": {
            "type": "object",
            "properties": {
                "flag1": { "type": "boolean", "ex:bitOffset": 3, "ex:bitLength": 1 },
                "flag2": { "type": "boolean", "ex:bitOffset": 4, "ex:bitLength": 1 },
            },
            "ex:bitOffset": 8,
            "ex:bitLength": 8,
        },
    },
    "ex:bitLength": 16,
},
"application/octet-stream;length=2;"
```
I would expect: `0000 1000 0001 0000`, i.e. `Buffer[8, 16]`, but the current implementation returns `Buffer[24, 0]` because it does not pass `ex:bitOffset` of `flags2` and therefore sets the bits of `flags2` in the same byte as `flags1` writing `0001 1000 0000 0000`.

---

The issue when deserializing nested objects was that `bytesToValue` would only pass the bytes from `offset` to `offset` + `length` to `objectToValue` without adjusting the `length` parameter. Therefore, deserializing nested objects would throw an error:
```
Error: Lengths do not match, required: 2 provided: 1
```
I added a test case and a fix for this, too.