### PR TITLE
fix(cli): move serverKey and serverCert under http

### DIFF
--- a/packages/cli/src/wot-servient-schema.conf.json
+++ b/packages/cli/src/wot-servient-schema.conf.json
@@ -16,17 +16,7 @@
                 "scriptAction": {
                     "type": "boolean",
                     "default": false
-                },
-                "serverKey": {
-                    "type": "string"
-                },
-                "serverCert": {
-                    "type": "string"
                 }
-            },
-            "dependencies": {
-                "serverKey": ["serverCert"],
-                "serverCert": ["serverKey"]
             }
         },
         "http": {
@@ -68,6 +58,12 @@
                 },
                 "allowSelfSigned": {
                     "type": "boolean"
+                },
+                "serverKey": {
+                    "type": "string"
+                },
+                "serverCert": {
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
Note: the PR also removed the following from "servient"

```
            "dependencies": {
                "serverKey": ["serverCert"],
                "serverCert": ["serverKey"]
            }
```

since 
* `dependencies` are now `dependentRequired` and `dependentSchemas`
* and deals with subschemas which we don't use

Am I wrong?

fixes https://github.com/eclipse-thingweb/node-wot/issues/839