### PR TITLE
Console warning when no subprotocol is defined in http form

### DIFF
--- a/packages/binding-http/src/http-client-impl.ts
+++ b/packages/binding-http/src/http-client-impl.ts
@@ -158,7 +158,12 @@ export default class HttpClient implements ProtocolClient {
         complete?: () => void
     ): Promise<Subscription> {
         const defaultSubprotocol = "longpoll";
-        const subprotocol = form.subprotocol ?? defaultSubprotocol;
+        let subprotocol = form.subprotocol;
+
+        if (subprotocol == null) {
+            warn(`Subscribing to ${form.href} using long polling for form without subprotocol`);
+            subprotocol = defaultSubprotocol;
+        }
 
         let internalSubscription: InternalSubscription;
         if (subprotocol === defaultSubprotocol) {


### PR DESCRIPTION
Giving the discussion in #1281 I added a warning message if the client is falling back to default protocol (longpoll for us). Please let me know if we can improve the logged message or anything else. 