### PR TITLE
fix(coap): wrong error variable name

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -809,7 +809,7 @@ export default class CoapServer implements ProtocolServer {
             } else {
                 this.sendChangedResponse(res);
             }
-        } catch (errror) {
+        } catch (error) {
             const errorMessage = `${error}`;
             error(`CoapServer on port ${this.getPort()} got internal error on invoke '${req.url}': ${errorMessage}`);
             this.sendResponse(res, "5.00", errorMessage);

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -809,8 +809,8 @@ export default class CoapServer implements ProtocolServer {
             } else {
                 this.sendChangedResponse(res);
             }
-        } catch (error) {
-            const errorMessage = `${error}`;
+        } catch (err) {
+            const errorMessage = `${err}`;
             error(`CoapServer on port ${this.getPort()} got internal error on invoke '${req.url}': ${errorMessage}`);
             this.sendResponse(res, "5.00", errorMessage);
         }


### PR DESCRIPTION
Note: interesting that this is not detected automatically... `error` exists as import also...