### PR TITLE
chore(td-tools): deprecate thing-model-helpers' exports

### DIFF
--- a/packages/td-tools/src/thing-model-helpers.ts
+++ b/packages/td-tools/src/thing-model-helpers.ts
@@ -60,7 +60,6 @@ export type ModelImportsInput = {
     name: string;
 };
 
-
 /**
  * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */

--- a/packages/td-tools/src/thing-model-helpers.ts
+++ b/packages/td-tools/src/thing-model-helpers.ts
@@ -36,24 +36,23 @@ const tmSchema = TMSchema;
 const ajv = new Ajv({ strict: false });
 addFormats(ajv);
 
-
 /**
- * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */
 export type LINK_TYPE = "tm:extends" | "tm:submodel";
 
 /**
- * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */
 export type AFFORDANCE_TYPE = "properties" | "actions" | "events";
 
 /**
- * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */
 export type COMPOSITION_TYPE = "extends" | "imports";
 
 /**
- * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */
 export type ModelImportsInput = {
     uri?: string;
@@ -63,7 +62,7 @@ export type ModelImportsInput = {
 
 
 /**
- * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */
 export type CompositionOptions = {
     baseUrl?: string;
@@ -72,7 +71,7 @@ export type CompositionOptions = {
 };
 
 /**
- * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */
 export type modelComposeInput = {
     extends?: ThingModel[];
@@ -81,7 +80,7 @@ export type modelComposeInput = {
 };
 
 /**
- * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ * @deprecated This package and therefore its functionality will be removed in the future. Please use '@thingweb/thing-model' package instead.
  */
 export class ThingModelHelpers {
     static tsSchemaValidator = ajv.compile(tmSchema) as ValidateFunction;

--- a/packages/td-tools/src/thing-model-helpers.ts
+++ b/packages/td-tools/src/thing-model-helpers.ts
@@ -36,26 +36,53 @@ const tmSchema = TMSchema;
 const ajv = new Ajv({ strict: false });
 addFormats(ajv);
 
+
+/**
+ * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ */
 export type LINK_TYPE = "tm:extends" | "tm:submodel";
+
+/**
+ * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ */
 export type AFFORDANCE_TYPE = "properties" | "actions" | "events";
+
+/**
+ * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ */
 export type COMPOSITION_TYPE = "extends" | "imports";
+
+/**
+ * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ */
 export type ModelImportsInput = {
     uri?: string;
     type: AFFORDANCE_TYPE;
     name: string;
 };
 
+
+/**
+ * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ */
 export type CompositionOptions = {
     baseUrl?: string;
     selfComposition?: boolean;
     map?: Record<string, unknown>;
 };
+
+/**
+ * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ */
 export type modelComposeInput = {
     extends?: ThingModel[];
     imports?: (ModelImportsInput & { affordance: DataSchema })[];
     submodel?: Record<string, ThingModel>;
 };
 
+/**
+ * @deprecated This package and therefore its functionality will be removed in the future. Please instead use '@thingweb/thing-model' package.
+ */
 export class ThingModelHelpers {
     static tsSchemaValidator = ajv.compile(tmSchema) as ValidateFunction;
 


### PR DESCRIPTION
fixes https://github.com/eclipse-thingweb/node-wot/pull/1306