### PR TITLE
fix(core/interactionOutput): support for no-type based root schemas

### DIFF
--- a/packages/core/src/interaction-output.ts
+++ b/packages/core/src/interaction-output.ts
@@ -104,7 +104,12 @@ export class InteractionOutput implements WoT.InteractionOutput {
             throw new NotReadableError("No form defined");
         }
 
-        if (this.schema.type == null) {
+        if (
+            this.schema.const == null &&
+            this.schema.enum == null &&
+            this.schema.oneOf == null &&
+            this.schema.type == null
+        ) {
             throw new NotReadableError("No schema type defined");
         }
 

--- a/packages/core/test/InteractionOutputTest.ts
+++ b/packages/core/test/InteractionOutputTest.ts
@@ -216,4 +216,40 @@ class InteractionOutputTests {
         const result = out.value<number>();
         return expect(result).to.eventually.be.rejected;
     }
+
+    @test async "should return null"() {
+        const stream = Readable.from(Buffer.from("null", "utf-8"));
+        const content = new Content("application/json", stream);
+
+        const out = new InteractionOutput(content, {}, { type: "null" });
+        const result = await out.value<null>();
+        expect(result).to.be.eq(null);
+    }
+
+    @test async "should support oneOf"() {
+        const stream = Readable.from(Buffer.from('"hello"', "utf-8"));
+        const content = new Content("application/json", stream);
+
+        const out = new InteractionOutput(content, {}, { oneOf: [{ type: "string" }, { type: "null" }] });
+        const result = await out.value<string | null>();
+        expect(result).to.be.eq("hello");
+    }
+
+    @test async "should support const"() {
+        const stream = Readable.from(Buffer.from("42", "utf-8"));
+        const content = new Content("application/json", stream);
+
+        const out = new InteractionOutput(content, {}, { const: 42 });
+        const result = await out.value<42>();
+        expect(result).to.be.eq(42);
+    }
+
+    @test async "should support enum"() {
+        const stream = Readable.from(Buffer.from('"red"', "utf-8"));
+        const content = new Content("application/json", stream);
+
+        const out = new InteractionOutput(content, {}, { enum: ["red", "amber", "green"] });
+        const result = await out.value<"red" | "amber" | "green">();
+        expect(result).to.be.eq("red");
+    }
 }


### PR DESCRIPTION
As discussed in #1243 and solved in https://github.com/w3c/wot-scripting-api/pull/534, we now allow more root schema types to be accepted in the value function. The validation still happens but it supports: `const`, `enum`, and `oneOf`. Those terms can now be used instead of `type`. The behavior of using these terms **at the same time** is delegated to Ajv.validate function. 