### PR TITLE
docs: add deprecation message to td-tools

### DIFF
--- a/packages/td-tools/src/td-helpers.ts
+++ b/packages/td-tools/src/td-helpers.ts
@@ -43,6 +43,9 @@ export function findPort(td: ThingDescription): number {
     return parseInt(returnString);
 }
 
+/**
+ * @deprecated This function will be removed in the future.
+ */
 export function setContextLanguage(thing: ThingDescription, language: string, forceOverride: boolean): void {
     // forceOverride == false -> set @language if no @language set
     // forceOverride == true  -> set/override @language in any case

--- a/packages/td-tools/src/td-parser.ts
+++ b/packages/td-tools/src/td-parser.ts
@@ -55,7 +55,10 @@ function adjustBooleanField(affordance: AffordanceElement, key: string) {
     }
 }
 
-/** Parses a TD into a Thing object */
+/** Parses a TD into a Thing object
+ *
+ * @deprecated This function will be removed in the future.
+ */
 export function parseTD(td: string, normalize?: boolean): Thing {
     logDebug(`parseTD() parsing\n\`\`\`\n${td}\n\`\`\``);
 
@@ -220,7 +223,10 @@ export function parseTD(td: string, normalize?: boolean): Thing {
     return thing;
 }
 
-/** Serializes a Thing object into a TD */
+/** Serializes a Thing object into a TD
+ *
+ * @deprecated This function will be removed in the future.
+ */
 export function serializeTD(thing: Thing): string {
     const copy: Thing = JSON.parse(JSON.stringify(thing));
 


### PR DESCRIPTION
What about https://github.com/eclipse-thingweb/node-wot/blob/master/packages/td-tools/src/thing-description.ts

It will continue to live in `core`, right? 