### PR TITLE
feat(binding-coap): remove cov:observe subprotocol

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -35,7 +35,7 @@ import { MdnsIntroducer } from "./mdns-introducer";
 import { PropertyElement, DataSchema, ActionElement, EventElement } from "wot-thing-description-types";
 import { CoapServerConfig } from "./coap";
 import { DataSchemaValue } from "wot-typescript-definitions";
-import { filterPropertyObserveOperations, getPropertyOpValues } from "./util";
+import { getPropertyOpValues } from "./util";
 
 const { debug, warn, info, error } = createLoggers("binding-coap", "coap-server");
 
@@ -248,14 +248,6 @@ export default class CoapServer implements ProtocolServer {
                     continue;
                 }
 
-                let subprotocol: string | undefined;
-
-                const observeOpValues = filterPropertyObserveOperations(formOpValues);
-
-                if (observeOpValues.length > 0) {
-                    subprotocol = "cov:observe";
-                }
-
                 const form = this.createAffordanceForm(
                     base,
                     this.PROPERTY_DIR,
@@ -263,8 +255,7 @@ export default class CoapServer implements ProtocolServer {
                     formOpValues,
                     thing.uriVariables,
                     propertyName,
-                    property.uriVariables,
-                    subprotocol
+                    property.uriVariables
                 );
 
                 this.addFormToAffordance(form, property);
@@ -299,8 +290,7 @@ export default class CoapServer implements ProtocolServer {
                 ["subscribeevent", "unsubscribeevent"],
                 thing.uriVariables,
                 eventName,
-                event.uriVariables,
-                "cov:observe"
+                event.uriVariables
             );
 
             this.addFormToAffordance(form, event);

--- a/packages/binding-coap/src/util.ts
+++ b/packages/binding-coap/src/util.ts
@@ -60,11 +60,10 @@ export function filterEventOperations(opValues: string[]) {
 /**
  * Function to (potentially) generate two arrays of `op` values: One with the
  * values "readproperty" and "writeproperty", and one with
- * "observerproperty" and "unobserveproperty".
+ * "observeproperty" and "unobserveproperty".
  *
- * This CoAP-specific distinction is made to be able to generate
- * separate forms for the observe-related operations, where the addition
- * of a `subprotocol` field with a value of `cov:observe` has to be added.
+ * This distinction is made to be able to generate separate forms for the
+ * observe-related operations.
  *
  * @param property The property for which the forms are going to be
  *                 generated.

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -635,7 +635,7 @@ class CoapServerTest {
         await coapServer.stop();
     }
 
-    @test async "should add the cov:observe subprotocol value to observable properties and events "() {
+    @test async "should add the correct operation types to observable properties and events "() {
         const coapServer = new CoapServer({ port: 5683 });
         const servient = new Servient();
         servient.addServer(coapServer);
@@ -702,14 +702,17 @@ class CoapServerTest {
                 for (const event of Object.values(td.events!)) {
                     for (const form of event.forms) {
                         const opValues = form.op!;
-                        expect(opValues.length > 0);
+                        // eslint-disable-next-line no-unused-expressions
+                        expect(opValues.length > 0).to.be.true;
 
                         const eventOpValueCount = filterEventOperations(opValues as Array<string>).length;
                         const eventOpValueCountPresent = eventOpValueCount > 0;
 
-                        expect(eventOpValueCountPresent);
+                        // eslint-disable-next-line no-unused-expressions
+                        expect(eventOpValueCountPresent).to.be.true;
 
-                        expect(form.subprotocol === "cov:observe");
+                        // eslint-disable-next-line no-unused-expressions
+                        expect(form.subprotocol === "cov:observe").to.be.false;
                     }
                 }
 

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -679,7 +679,6 @@ class CoapServerTest {
 
                         if (observeOpValuePresent) {
                             observeOpValueFormCount++;
-                            expect(form.subprotocol).to.eql("cov:observe");
                         }
 
                         const readWriteOpValueCount = filterPropertyReadWriteOperations(


### PR DESCRIPTION
This PR incorporates the recent changes applied to the CoAP Binding Template document in https://github.com/w3c/wot-binding-templates/pull/353, removing the `cov:observe` subprotocol from the TDs that are generated when adding a CoAP server to a servient.

In order to better cover the consumer behavior described in the CoAP binding template (falling back to polling if the server does not support CoAP observe), some more work is needed that might also need to be applied to the underlying CoAP libraries. I will try to cover these aspects soon in a follow-up PR.