### PR TITLE
fix: add missing packages for serdes.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12290,7 +12290,9 @@
                 "cbor": "^8.1.0",
                 "content-type": "^1.0.5",
                 "debug": "^4.3.4",
+                "is-absolute-url": "3.0.3",
                 "uritemplate": "0.3.4",
+                "url-toolkit": "2.1.6",
                 "uuid": "^7.0.3",
                 "web-streams-polyfill": "^3.0.1"
             },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,9 @@
         "cbor": "^8.1.0",
         "content-type": "^1.0.5",
         "debug": "^4.3.4",
+        "is-absolute-url": "3.0.3",
         "uritemplate": "0.3.4",
+        "url-toolkit": "2.1.6",
         "uuid": "^7.0.3",
         "web-streams-polyfill": "^3.0.1"
     },


### PR DESCRIPTION
Note: I used the exact same version for `is-absolute-url` and `url-toolkit` as in https://github.com/eclipse-thingweb/node-wot/blob/f63b72951fa9190ced8126e2f6b4cfe045b148bf/packages/td-tools/package.json#L20-L22 to avoid issues.

fixes https://github.com/eclipse-thingweb/node-wot/issues/1317