### PR TITLE
chore: increase version numbers to 0.8.17 for next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -547,9 +547,9 @@
             }
         },
         "node_modules/@peculiar/x509": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.11.0.tgz",
-            "integrity": "sha512-8rdxE//tsWLb2Yo2TYO2P8gieStbrHK/huFMV5PPfwX8I5HmtOus+Ox6nTKrPA9o+WOPaa5xKenee+QdmHBd5g==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.1.tgz",
+            "integrity": "sha512-2T9t2viNP9m20mky50igPTpn2ByhHl5NlT6wW4Tp4BejQaQ5XDNZgfsabYwYysLXhChABlgtTCpp2gM3JBZRKA==",
             "dependencies": {
                 "@peculiar/asn1-cms": "^2.3.8",
                 "@peculiar/asn1-csr": "^2.3.8",
@@ -825,9 +825,9 @@
             }
         },
         "node_modules/@sinonjs/text-encoding": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-            "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+            "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
             "dev": true
         },
         "node_modules/@ster5/global-mutex": {
@@ -2093,9 +2093,9 @@
             }
         },
         "node_modules/async": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -3904,9 +3904,9 @@
             "dev": true
         },
         "node_modules/elliptic": {
-            "version": "6.5.6",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-            "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+            "version": "6.5.7",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+            "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
             "dev": true,
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -5901,9 +5901,9 @@
             ]
         },
         "node_modules/ignore": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -7108,9 +7108,9 @@
             }
         },
         "node_modules/mqtt": {
-            "version": "5.9.1",
-            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.9.1.tgz",
-            "integrity": "sha512-FMENfSUMfCSUCnkuUVAL4U01795SUEfrX0NZ53HNr1r2VNpwKhR5Au9viq9WCFGtgrDAmsll4fkloqFCFgStYA==",
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.10.0.tgz",
+            "integrity": "sha512-2qpkUi5Ftp8cBX4sPCh/yr4ULBfLFQkjlhTGVpilHznOlsmDWIligmT1anSaJ1FqiH29RONNZJXhcJQaFwddgQ==",
             "dependencies": {
                 "@types/readable-stream": "^4.0.5",
                 "@types/ws": "^8.5.9",
@@ -7120,7 +7120,6 @@
                 "help-me": "^5.0.0",
                 "lru-cache": "^10.0.1",
                 "minimist": "^1.2.8",
-                "mqtt": "^5.2.0",
                 "mqtt-packet": "^9.0.0",
                 "number-allocator": "^1.0.14",
                 "readable-stream": "^4.4.2",
@@ -12095,10 +12094,10 @@
         },
         "packages/binding-coap": {
             "name": "@node-wot/binding-coap",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16",
+                "@node-wot/core": "0.8.17",
                 "@types/node": "16.18.35",
                 "coap": "^1.4.0",
                 "multicast-dns": "^7.2.5",
@@ -12110,18 +12109,18 @@
         },
         "packages/binding-file": {
             "name": "@node-wot/binding-file",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16"
+                "@node-wot/core": "0.8.17"
             }
         },
         "packages/binding-http": {
             "name": "@node-wot/binding-http",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16",
+                "@node-wot/core": "0.8.17",
                 "@types/eventsource": "1.1.10",
                 "accept-language-parser": "1.5.0",
                 "basic-auth": "2.0.1",
@@ -12146,20 +12145,20 @@
         },
         "packages/binding-mbus": {
             "name": "@node-wot/binding-mbus",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16",
+                "@node-wot/core": "0.8.17",
                 "node-mbus": "^2.2.4",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
             }
         },
         "packages/binding-modbus": {
             "name": "@node-wot/binding-modbus",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16",
+                "@node-wot/core": "0.8.17",
                 "modbus-serial": "^8.0.17",
                 "rxjs": "5.5.11",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
@@ -12167,10 +12166,10 @@
         },
         "packages/binding-mqtt": {
             "name": "@node-wot/binding-mqtt",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16",
+                "@node-wot/core": "0.8.17",
                 "aedes": "^0.46.2",
                 "mqtt": "^5.3.2",
                 "rxjs": "5.5.11"
@@ -12178,10 +12177,10 @@
         },
         "packages/binding-netconf": {
             "name": "@node-wot/binding-netconf",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16",
+                "@node-wot/core": "0.8.17",
                 "@types/node-netconf": "npm:@types/netconf@^2.0.0",
                 "@types/url-parse": "^1.4.3",
                 "case-1.5.3": "npm:case@^1.5.3",
@@ -12191,10 +12190,10 @@
         },
         "packages/binding-opcua": {
             "name": "@node-wot/binding-opcua",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/core": "0.8.16",
+                "@node-wot/core": "0.8.17",
                 "node-opcua": "2.113.0",
                 "node-opcua-address-space": "2.113.0",
                 "node-opcua-basic-types": "2.113.0",
@@ -12226,18 +12225,18 @@
         },
         "packages/binding-websockets": {
             "name": "@node-wot/binding-websockets",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-http": "0.8.16",
-                "@node-wot/core": "0.8.16",
+                "@node-wot/binding-http": "0.8.17",
+                "@node-wot/core": "0.8.17",
                 "slugify": "^1.4.5",
                 "ws": "^7.5.10"
             }
         },
         "packages/browser-bundle": {
             "name": "@node-wot/browser-bundle",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "events": "^2.1.0",
@@ -12245,24 +12244,24 @@
                 "resolve": "^1.1.7"
             },
             "devDependencies": {
-                "@node-wot/binding-http": "0.8.16",
-                "@node-wot/binding-websockets": "0.8.16",
-                "@node-wot/core": "0.8.16",
+                "@node-wot/binding-http": "0.8.17",
+                "@node-wot/binding-websockets": "0.8.17",
+                "@node-wot/core": "0.8.17",
                 "browserify": "^17.0.0",
                 "readable-stream4": "npm:readable-stream@^4.0.0"
             }
         },
         "packages/cli": {
             "name": "@node-wot/cli",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.16",
-                "@node-wot/binding-file": "0.8.16",
-                "@node-wot/binding-http": "0.8.16",
-                "@node-wot/binding-mqtt": "0.8.16",
-                "@node-wot/binding-websockets": "0.8.16",
-                "@node-wot/core": "0.8.16",
+                "@node-wot/binding-coap": "0.8.17",
+                "@node-wot/binding-file": "0.8.17",
+                "@node-wot/binding-http": "0.8.17",
+                "@node-wot/binding-mqtt": "0.8.17",
+                "@node-wot/binding-websockets": "0.8.17",
+                "@node-wot/core": "0.8.17",
                 "@thingweb/thing-model": "^1.0.1",
                 "@types/lodash": "^4.14.199",
                 "ajv": "^8.11.0",
@@ -12280,7 +12279,7 @@
         },
         "packages/core": {
             "name": "@node-wot/core",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "@petamoriken/float16": "^3.1.1",
@@ -12321,21 +12320,21 @@
         },
         "packages/examples": {
             "name": "@node-wot/examples",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
-                "@node-wot/binding-coap": "0.8.16",
-                "@node-wot/binding-file": "0.8.16",
-                "@node-wot/binding-http": "0.8.16",
-                "@node-wot/binding-mqtt": "0.8.16",
-                "@node-wot/binding-opcua": "0.8.16",
-                "@node-wot/core": "0.8.16",
+                "@node-wot/binding-coap": "0.8.17",
+                "@node-wot/binding-file": "0.8.17",
+                "@node-wot/binding-http": "0.8.17",
+                "@node-wot/binding-mqtt": "0.8.17",
+                "@node-wot/binding-opcua": "0.8.17",
+                "@node-wot/core": "0.8.17",
                 "rxjs": "5.5.11"
             }
         },
         "packages/td-tools": {
             "name": "@node-wot/td-tools",
-            "version": "0.8.16",
+            "version": "0.8.17",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "ajv": "^8.11.0",

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-coap",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "CoAP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,7 +14,7 @@
     "main": "dist/coap.js",
     "types": "dist/coap.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.16",
+        "@node-wot/core": "0.8.17",
         "@types/node": "16.18.35",
         "coap": "^1.4.0",
         "multicast-dns": "^7.2.5",

--- a/packages/binding-file/package.json
+++ b/packages/binding-file/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-file",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "File client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,7 +14,7 @@
     "main": "dist/file.js",
     "types": "dist/file.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.16"
+        "@node-wot/core": "0.8.17"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-http",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "HTTP client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -28,7 +28,7 @@
         "timekeeper": "^2.2.0"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.16",
+        "@node-wot/core": "0.8.17",
         "@types/eventsource": "1.1.10",
         "accept-language-parser": "1.5.0",
         "basic-auth": "2.0.1",

--- a/packages/binding-mbus/package.json
+++ b/packages/binding-mbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mbus",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "M-Bus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,7 +14,7 @@
     "main": "dist/mbus.js",
     "types": "dist/mbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.16",
+        "@node-wot/core": "0.8.17",
         "node-mbus": "^2.2.4",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
     },

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-modbus",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "Modbus TCP client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "contributors": [
@@ -17,7 +17,7 @@
     "main": "dist/modbus.js",
     "types": "dist/modbus.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.16",
+        "@node-wot/core": "0.8.17",
         "modbus-serial": "^8.0.17",
         "rxjs": "5.5.11",
         "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"

--- a/packages/binding-mqtt/package.json
+++ b/packages/binding-mqtt/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-mqtt",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "MQTT binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,7 +14,7 @@
     "main": "dist/mqtt.js",
     "types": "dist/mqtt.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.16",
+        "@node-wot/core": "0.8.17",
         "aedes": "^0.46.2",
         "mqtt": "^5.3.2",
         "rxjs": "5.5.11"

--- a/packages/binding-netconf/package.json
+++ b/packages/binding-netconf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-netconf",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "NetConf client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -14,7 +14,7 @@
     "main": "dist/netconf.js",
     "types": "dist/netconf.d.ts",
     "dependencies": {
-        "@node-wot/core": "0.8.16",
+        "@node-wot/core": "0.8.17",
         "@types/node-netconf": "npm:@types/netconf@^2.0.0",
         "@types/url-parse": "^1.4.3",
         "case-1.5.3": "npm:case@^1.5.3",

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-opcua",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "opcua client protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -18,7 +18,7 @@
         "should": "^13.2.3"
     },
     "dependencies": {
-        "@node-wot/core": "0.8.16",
+        "@node-wot/core": "0.8.17",
         "node-opcua": "2.113.0",
         "node-opcua-address-space": "2.113.0",
         "node-opcua-basic-types": "2.113.0",

--- a/packages/binding-websockets/package.json
+++ b/packages/binding-websockets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/binding-websockets",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "WebSockets client & server protocol binding for node-wot",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -15,8 +15,8 @@
     "types": "dist/ws.d.ts",
     "browser": "dist/ws-browser.js",
     "dependencies": {
-        "@node-wot/binding-http": "0.8.16",
-        "@node-wot/core": "0.8.16",
+        "@node-wot/binding-http": "0.8.17",
+        "@node-wot/core": "0.8.17",
         "slugify": "^1.4.5",
         "ws": "^7.5.10"
     },

--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/browser-bundle",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "A node-wot bundle that can run in a web browser",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -13,9 +13,9 @@
     ],
     "main": "dist/wot-bundle.min.js",
     "devDependencies": {
-        "@node-wot/binding-http": "0.8.16",
-        "@node-wot/binding-websockets": "0.8.16",
-        "@node-wot/core": "0.8.16",
+        "@node-wot/binding-http": "0.8.17",
+        "@node-wot/binding-websockets": "0.8.17",
+        "@node-wot/core": "0.8.17",
         "browserify": "^17.0.0",
         "readable-stream4": "npm:readable-stream@^4.0.0"
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/cli",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "servient command line interface",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
@@ -20,12 +20,12 @@
         "ts-node": "10.9.1"
     },
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.16",
-        "@node-wot/binding-file": "0.8.16",
-        "@node-wot/binding-http": "0.8.16",
-        "@node-wot/binding-mqtt": "0.8.16",
-        "@node-wot/binding-websockets": "0.8.16",
-        "@node-wot/core": "0.8.16",
+        "@node-wot/binding-coap": "0.8.17",
+        "@node-wot/binding-file": "0.8.17",
+        "@node-wot/binding-http": "0.8.17",
+        "@node-wot/binding-mqtt": "0.8.17",
+        "@node-wot/binding-websockets": "0.8.17",
+        "@node-wot/core": "0.8.17",
         "@thingweb/thing-model": "^1.0.1",
         "@types/lodash": "^4.14.199",
         "ajv": "^8.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/core",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "W3C Web of Things (WoT) Servient framework",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,18 +1,18 @@
 {
     "name": "@node-wot/examples",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "private": true,
     "description": "Examples for node-wot (not published)",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
     "repository": "https://github.com/eclipse-thingweb/node-wot/tree/master/packages/examples",
     "dependencies": {
-        "@node-wot/binding-coap": "0.8.16",
-        "@node-wot/binding-file": "0.8.16",
-        "@node-wot/binding-http": "0.8.16",
-        "@node-wot/binding-mqtt": "0.8.16",
-        "@node-wot/binding-opcua": "0.8.16",
-        "@node-wot/core": "0.8.16",
+        "@node-wot/binding-coap": "0.8.17",
+        "@node-wot/binding-file": "0.8.17",
+        "@node-wot/binding-http": "0.8.17",
+        "@node-wot/binding-mqtt": "0.8.17",
+        "@node-wot/binding-opcua": "0.8.17",
+        "@node-wot/core": "0.8.17",
         "rxjs": "5.5.11"
     },
     "scripts": {

--- a/packages/td-tools/package.json
+++ b/packages/td-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@node-wot/td-tools",
-    "version": "0.8.16",
+    "version": "0.8.17",
     "description": "W3C Web of Things (WoT) Thing Description parser, serializer, and other tools",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",


### PR DESCRIPTION
FYI: As usual, every time we update the node-wot package versions we also newly create `package-lock.json` to update dependencies.
Hence one can see many changes for `package-lock.json` ...