### PR TITLE
chore: Simplify the workspaces list

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "workspaces": [
         "./packages/td-tools",
         "./packages/core",
-        "./packages/binding-!()",
+        "./packages/binding-*",
         "./packages/cli",
         "./packages/examples",
         "./packages/browser-bundle"


### PR DESCRIPTION
Incidentally unbreaks `deno install`.