### PR TITLE
Follow-up for PR 1335

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@types/chai-as-promised": "^7.1.4",
                 "@types/chai-spies": "^1.0.4",
                 "@types/mocha": "^9.0.0",
-                "@types/node": "22.13.1",
+                "@types/node": "^18.19.76",
                 "@types/readable-stream": "^4.0.15",
                 "@types/sinon": "10.0.2",
                 "@typescript-eslint/eslint-plugin": "^6.7.3",
@@ -1471,11 +1471,12 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "22.13.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-            "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+            "version": "18.19.76",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
+            "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
+            "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.20.0"
+                "undici-types": "~5.26.4"
             }
         },
         "node_modules/@types/node-fetch": {
@@ -11081,9 +11082,10 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "license": "MIT"
         },
         "node_modules/unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@types/chai-as-promised": "^7.1.4",
         "@types/chai-spies": "^1.0.4",
         "@types/mocha": "^9.0.0",
-        "@types/node": "22.13.1",
+        "@types/node": "^18.19.76",
         "@types/readable-stream": "^4.0.15",
         "@types/sinon": "10.0.2",
         "@typescript-eslint/eslint-plugin": "^6.7.3",

--- a/packages/binding-opcua/tsconfig.json
+++ b/packages/binding-opcua/tsconfig.json
@@ -3,9 +3,7 @@
     "compilerOptions": {
         "outDir": "dist",
         "rootDir": "src",
-        "skipLibCheck": true,
-        "module": "Node16",
-        "moduleResolution": "Node16"
+        "skipLibCheck": true
     },
     "include": ["./src/**/*"],
     "references": [{ "path": "../td-tools" }, { "path": "../core" }]


### PR DESCRIPTION
Follow-up for https://github.com/eclipse-thingweb/node-wot/pull/1335

Tackles the following discussions

* no need to duplicate configuration options, see https://github.com/eclipse-thingweb/node-wot/pull/1335#discussion_r1942427717
* revert @types/node version back to v18, see https://github.com/eclipse-thingweb/node-wot/pull/1335#discussion_r1942430544
* ~~the aspect about   "module": "commonjs" vs "Node16" is taken care of in https://github.com/eclipse-thingweb/node-wot/pull/1348 , see https://github.com/eclipse-thingweb/node-wot/pull/1335#discussion_r1942425485~~