### PR TITLE
Update browser-test.yml with clearer job name

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -9,7 +9,7 @@ on:
         branches: [master]
 
 jobs:
-    test:
+    test-browser:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
At the moment, it is not clear in the GitHub UI "what" is tested with this run

![grafik](https://github.com/user-attachments/assets/822deac7-24e0-47b8-8836-26a5c3f578f4)


