### PR TITLE
Handle long streams as inputs in HTTP binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9918,48 +9918,6 @@
                 "node-aead-crypto": "^2.0.0"
             }
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-fetch/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
-        },
-        "node_modules/node-fetch/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/node-fetch/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/node-gyp-build": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
@@ -15600,7 +15558,7 @@
                 "client-oauth2": "^4.2.5",
                 "eventsource": "^2.0.2",
                 "find-my-way": "^8.2.2",
-                "node-fetch": "^2.6.7",
+                "node-fetch": "^2.7.0",
                 "query-string": "^7.1.1",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5"
@@ -15639,6 +15597,44 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "packages/binding-http/node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/binding-http/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "packages/binding-http/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "packages/binding-http/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "packages/binding-mbus": {

--- a/packages/binding-http/package.json
+++ b/packages/binding-http/package.json
@@ -39,7 +39,7 @@
         "client-oauth2": "^4.2.5",
         "eventsource": "^2.0.2",
         "find-my-way": "^8.2.2",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.7.0",
         "query-string": "^7.1.1",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5"

--- a/packages/binding-http/src/http-client-impl.ts
+++ b/packages/binding-http/src/http-client-impl.ts
@@ -410,8 +410,12 @@ export default class HttpClient implements ProtocolClient {
         return request;
     }
 
-    private async fetch(request: Request, content?: Content) {
-        const result = await fetch(request, { body: content?.body });
+    private async fetch(request: Request) {
+        // TODO: need investigation. Even if the request has already a body
+        // if we don't pass it again to the fetch as request init the stream is
+        // not correctly consumed
+        // see https://github.com/eclipse-thingweb/node-wot/issues/1366.
+        const result = await fetch(request, { body: request.body });
 
         if (HttpClient.isOAuthTokenExpired(result, this.credential)) {
             this.credential = await (this.credential as OAuthCredential).refreshToken();


### PR DESCRIPTION
This simple PR fixes #1366 by forcefully passing the request body to the node-fetch operation. I did some experiments. Basically, previously, the content parameter in the private fetch function was redundant, as it was never actually passed. That surprised me, Then I looked in the generateFetchRequest and found that we were already handling the body in that function. Removing it didn't solve the problem, but then I noticed that if I forcefully pass the body directly in the fetch RequestInit argument, then the stream is consumed correctly. I reproduced the error (the need to pass the body to request init) without using node-wot at all so I assumed that there should be something wrong with node-fetch (digging into its code, there is probably something when it clones the ReadableStream). Therefore, I left a comment for future review. Headers and other parameters seem not to be impacted. 

While I was at it, I upgraded node-fetch to the last compatible version (3.x works only with ESM). 