### PR TITLE
chore: Node.js 18 end of life

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest, windows-latest]
-                node-version: [18.x, 20.x, 22.x]
+                node-version: [20.x, 22.x]
 
         timeout-minutes: 30
 
@@ -76,10 +76,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Use Node.js 18
+            - name: Use Node.js 20
               uses: actions/setup-node@v1
               with:
-                  node-version: 18
+                  node-version: 20
 
             - name: Install
               run: npm ci
@@ -92,10 +92,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - name: install node v18
+            - name: install node v20
               uses: actions/setup-node@v1
               with:
-                  node-version: 18
+                  node-version: 20
             - name: verify packages version consistency accross sub-modules
               run: npm run check:versions
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The framework is composed by different packages that users can use as they pleas
 #### Node.js
 
 > [!WARNING]
-> We no longer actively support Node.js version 20 and lower.
+> We no longer actively support Node.js version 18 and lower.
 
 -   [Node.js](https://nodejs.org/) version 20+
 -   [npm](https://www.npmjs.com/) version 9+

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ The framework is composed by different packages that users can use as they pleas
 #### Node.js
 
 > [!WARNING]
-> We no longer actively support Node.js version 16 and lower.
+> We no longer actively support Node.js version 20 and lower.
 
--   [Node.js](https://nodejs.org/) version 18+
+-   [Node.js](https://nodejs.org/) version 20+
 -   [npm](https://www.npmjs.com/) version 9+
 
 Platforms specific prerequisites:


### PR DESCRIPTION
support ends on 30 Apr 2025