### PR TITLE
refactor: generate unique names/urls locally

### DIFF
--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -160,8 +160,14 @@ export default class CoapServer implements ProtocolServer {
     private createThingUrlPath(thing: ExposedThing) {
         let urlPath = slugify(thing.title, { lower: true });
 
-        while (this.things.has(urlPath)) {
-            urlPath += "_";
+        // avoid URL clashes
+        if (this.things.has(urlPath)) {
+            let uniqueUrlPath;
+            let nameClashCnt = 2;
+            do {
+                uniqueUrlPath = urlPath + "_" + nameClashCnt++;
+            } while (this.things.has(uniqueUrlPath));
+            urlPath = uniqueUrlPath;
         }
 
         return urlPath;

--- a/packages/binding-coap/src/coap-server.ts
+++ b/packages/binding-coap/src/coap-server.ts
@@ -158,10 +158,10 @@ export default class CoapServer implements ProtocolServer {
     }
 
     private createThingUrlPath(thing: ExposedThing) {
-        const urlPath = slugify(thing.title, { lower: true });
+        let urlPath = slugify(thing.title, { lower: true });
 
-        if (this.things.has(urlPath)) {
-            return Helpers.generateUniqueName(urlPath);
+        while (this.things.has(urlPath)) {
+            urlPath += "_";
         }
 
         return urlPath;

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -269,8 +269,8 @@ export default class HttpServer implements ProtocolServer {
     public async expose(thing: ExposedThing, tdTemplate: WoT.ExposedThingInit = {}): Promise<void> {
         let urlPath = slugify(thing.title, { lower: true });
 
-        if (this.things.has(urlPath)) {
-            urlPath = Helpers.generateUniqueName(urlPath);
+        while (this.things.has(urlPath)) {
+            urlPath += "_";
         }
 
         if (this.getPort() !== -1) {

--- a/packages/binding-http/src/http-server.ts
+++ b/packages/binding-http/src/http-server.ts
@@ -269,8 +269,14 @@ export default class HttpServer implements ProtocolServer {
     public async expose(thing: ExposedThing, tdTemplate: WoT.ExposedThingInit = {}): Promise<void> {
         let urlPath = slugify(thing.title, { lower: true });
 
-        while (this.things.has(urlPath)) {
-            urlPath += "_";
+        // avoid URL clashes
+        if (this.things.has(urlPath)) {
+            let uniqueUrlPath;
+            let nameClashCnt = 2;
+            do {
+                uniqueUrlPath = urlPath + "_" + nameClashCnt++;
+            } while (this.things.has(uniqueUrlPath));
+            urlPath = uniqueUrlPath;
         }
 
         if (this.getPort() !== -1) {

--- a/packages/binding-websockets/src/ws-server.ts
+++ b/packages/binding-websockets/src/ws-server.ts
@@ -158,8 +158,14 @@ export default class WebSocketServer implements ProtocolServer {
     public expose(thing: ExposedThing): Promise<void> {
         let urlPath = slugify(thing.title, { lower: true });
 
-        while (this.thingNames.has(urlPath)) {
-            urlPath += "_";
+        // avoid name clashes
+        if (this.thingNames.has(urlPath)) {
+            let uniqueUrlPath;
+            let nameClashCnt = 2;
+            do {
+                uniqueUrlPath = urlPath + "_" + nameClashCnt++;
+            } while (this.thingNames.has(uniqueUrlPath));
+            urlPath = uniqueUrlPath;
         }
 
         if (this.getPort() !== -1) {

--- a/packages/binding-websockets/src/ws-server.ts
+++ b/packages/binding-websockets/src/ws-server.ts
@@ -158,8 +158,8 @@ export default class WebSocketServer implements ProtocolServer {
     public expose(thing: ExposedThing): Promise<void> {
         let urlPath = slugify(thing.title, { lower: true });
 
-        if (this.thingNames.has(urlPath)) {
-            urlPath = Helpers.generateUniqueName(urlPath);
+        while (this.thingNames.has(urlPath)) {
+            urlPath += "_";
         }
 
         if (this.getPort() !== -1) {

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -124,6 +124,7 @@ export default class Helpers implements Resolver {
         return address;
     }
 
+    /** @deprecated see https://github.com/eclipse-thingweb/node-wot/issues/1351 */
     public static generateUniqueName(name: string): string {
         const suffix = name.match(/.+_([0-9]+)$/);
         if (suffix !== null) {


### PR DESCRIPTION
Yet another approach... (alternative for https://github.com/eclipse-thingweb/node-wot/pull/1352)

Advantages I see:
* each binding can choose the way it likes to create urls if there are thing name clashes. This is anyway a bit of a problematic case since no one can rely on the strategy since it depends on the order a thing has been added.
* no need for a helpers method
* no need to pass (and create) a set around with the existing names so far

fixes https://github.com/eclipse-thingweb/node-wot/issues/1351