### PR TITLE
chore: update Scripting TS dependencies (March 2025)

### DIFF
--- a/examples/templates/exposed-thing/package.json
+++ b/examples/templates/exposed-thing/package.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "devDependencies": {
         "typescript": "4.7.4",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.26",
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.30",
         "@types/node": "16.18.35",
         "tslint": "5.12.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1982,27 +1982,18 @@
             }
         },
         "node_modules/@thingweb/thing-model": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@thingweb/thing-model/-/thing-model-1.0.3.tgz",
-            "integrity": "sha512-KAm2ux3A7B2lq0LkQw1Eze4g1w1c1zvhlaCA/TQFtX5LQoMsm6uqMuW6X+PcOzSsyKIekxYQjcgwC4rFZpfDbg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@thingweb/thing-model/-/thing-model-1.0.4.tgz",
+            "integrity": "sha512-09oa2VVG2yGTXCKbXco25t5bQ5n/BG+BPhKoR/IZrEKLJVPbml20Y9VZusscTTRNxYR2VBrFdON+WhomtIRrdg==",
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "ajv": "^8.11.0",
                 "ajv-formats": "^3.0.1",
                 "debug": "^4.3.4",
                 "json-placeholder-replacer": "^2.0.4",
-                "wot-thing-description-types": "1.1.0-09-November-2023",
-                "wot-thing-model-types": "^1.1.0-09-November-2023",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
-            }
-        },
-        "node_modules/@thingweb/thing-model/node_modules/wot-typescript-definitions": {
-            "version": "0.8.0-SNAPSHOT.29",
-            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
-            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
-            "license": "W3C-20150513",
-            "dependencies": {
-                "wot-thing-description-types": "1.1.0-09-November-2023"
+                "wot-thing-description-types": "^1.1.0-12-March-2025",
+                "wot-thing-model-types": "^1.1.0-12-March-2025",
+                "wot-typescript-definitions": "^0.8.0-SNAPSHOT.30"
             }
         },
         "node_modules/@tootallnate/quickjs-emscripten": {
@@ -15145,15 +15136,15 @@
             "license": "Apache-2.0"
         },
         "node_modules/wot-thing-description-types": {
-            "version": "1.1.0-09-November-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-November-2023.tgz",
-            "integrity": "sha512-qgZ1Khg/L3SkIRSm4POVoj0P5MU4GIwxWdyQz2ckZzhnXesgPqe+AUzGxK37ArlxvaMytyjo0Cx2yfKoDHtlkA==",
+            "version": "1.1.0-12-March-2025",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-12-March-2025.tgz",
+            "integrity": "sha512-BRRW4uBATljCPqCbpzNhgY2HFXz8Llh7mAJmjkVimxizOPq8bkmlm0Op/Yv8l7pNQ1GaoBtYwn2BQQjhcQCadA==",
             "license": "W3C-20150513"
         },
         "node_modules/wot-thing-model-types": {
-            "version": "1.1.0-09-November-2023",
-            "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-09-November-2023.tgz",
-            "integrity": "sha512-BwmZGEG5VCth34RwXbQutFre7dcSanm1OhYve6lTxuGyqeRAQsj33CUrN5PjU5LSs68Xubm0FbKJZPvWGFa6LA==",
+            "version": "1.1.0-12-March-2025",
+            "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-12-March-2025.tgz",
+            "integrity": "sha512-YqCLluIONdr9m8p8euVqSrVFlyROWVhrI2CVZHGuGJfpm56xU2jtT4yFiZHumrnjKKwp0QfErX0YLB1uxdPNGg==",
             "license": "W3C-20150513"
         },
         "node_modules/wot-typescript-definitions": {
@@ -15164,12 +15155,6 @@
             "dependencies": {
                 "wot-thing-description-types": "1.1.0-12-March-2025"
             }
-        },
-        "node_modules/wot-typescript-definitions/node_modules/wot-thing-description-types": {
-            "version": "1.1.0-12-March-2025",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-12-March-2025.tgz",
-            "integrity": "sha512-BRRW4uBATljCPqCbpzNhgY2HFXz8Llh7mAJmjkVimxizOPq8bkmlm0Op/Yv8l7pNQ1GaoBtYwn2BQQjhcQCadA==",
-            "license": "W3C-20150513"
         },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",
@@ -15817,7 +15802,7 @@
                 "@node-wot/binding-mqtt": "0.9.2",
                 "@node-wot/binding-websockets": "0.9.2",
                 "@node-wot/core": "0.9.2",
-                "@thingweb/thing-model": "^1.0.1",
+                "@thingweb/thing-model": "^1.0.4",
                 "ajv": "^8.11.0",
                 "commander": "^9.1.0",
                 "dotenv": "^16.4.7",
@@ -15840,7 +15825,7 @@
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "@petamoriken/float16": "^3.1.1",
-                "@thingweb/thing-model": "^1.0.3",
+                "@thingweb/thing-model": "^1.0.4",
                 "ajv": "^8.11.0",
                 "ajv-formats": "^2.1.1",
                 "cbor": "^8.1.0",
@@ -15877,13 +15862,6 @@
                     "optional": true
                 }
             }
-        },
-        "packages/core/node_modules/wot-thing-description-types": {
-            "version": "1.1.0-12-March-2025",
-            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-12-March-2025.tgz",
-            "integrity": "sha512-BRRW4uBATljCPqCbpzNhgY2HFXz8Llh7mAJmjkVimxizOPq8bkmlm0Op/Yv8l7pNQ1GaoBtYwn2BQQjhcQCadA==",
-            "dev": true,
-            "license": "W3C-20150513"
         },
         "packages/examples": {
             "name": "@node-wot/examples",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "tslint": "5.12.1",
                 "typescript": "^5.7.3",
                 "typescript-standard": "^0.3.36",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.30"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1994,6 +1994,15 @@
                 "wot-thing-description-types": "1.1.0-09-November-2023",
                 "wot-thing-model-types": "^1.1.0-09-November-2023",
                 "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+            }
+        },
+        "node_modules/@thingweb/thing-model/node_modules/wot-typescript-definitions": {
+            "version": "0.8.0-SNAPSHOT.29",
+            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
+            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
+            "license": "W3C-20150513",
+            "dependencies": {
+                "wot-thing-description-types": "1.1.0-09-November-2023"
             }
         },
         "node_modules/@tootallnate/quickjs-emscripten": {
@@ -15148,13 +15157,19 @@
             "license": "W3C-20150513"
         },
         "node_modules/wot-typescript-definitions": {
-            "version": "0.8.0-SNAPSHOT.29",
-            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.29.tgz",
-            "integrity": "sha512-V5r/JSbFs/eaWgQavEEvaldjYoMuucJ9Ae0BDfUbSm6d9rJJYLEwfrwFKxBCD25Kdroea+kNlQMrYKk783OREQ==",
+            "version": "0.8.0-SNAPSHOT.30",
+            "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.30.tgz",
+            "integrity": "sha512-oDE1z+Seujd0mZKPoRRqdIbP3zoSldVJ8zwYwBi2O45VojxetcsF1C8lkO2fbPN+WwuzgxNBThmdU2M+c18v5Q==",
             "license": "W3C-20150513",
             "dependencies": {
-                "wot-thing-description-types": "1.1.0-09-November-2023"
+                "wot-thing-description-types": "1.1.0-12-March-2025"
             }
+        },
+        "node_modules/wot-typescript-definitions/node_modules/wot-thing-description-types": {
+            "version": "1.1.0-12-March-2025",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-12-March-2025.tgz",
+            "integrity": "sha512-BRRW4uBATljCPqCbpzNhgY2HFXz8Llh7mAJmjkVimxizOPq8bkmlm0Op/Yv8l7pNQ1GaoBtYwn2BQQjhcQCadA==",
+            "license": "W3C-20150513"
         },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",
@@ -15458,7 +15473,7 @@
                 "node-coap-client": "1.0.8",
                 "rxjs": "5.5.11",
                 "slugify": "^1.4.5",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.30"
             }
         },
         "packages/binding-file": {
@@ -15540,7 +15555,7 @@
                 "@node-wot/core": "0.9.2",
                 "modbus-serial": "8.0.17",
                 "rxjs": "5.5.11",
-                "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+                "wot-typescript-definitions": "0.8.0-SNAPSHOT.30"
             }
         },
         "packages/binding-mqtt": {
@@ -15843,7 +15858,7 @@
                 "@types/debug": "^4.1.7",
                 "@types/uritemplate": "^0.3.4",
                 "@types/uuid": "^8.3.1",
-                "wot-thing-description-types": "^1.1.0-09-November-2023"
+                "wot-thing-description-types": "^1.1.0-12-March-2025"
             }
         },
         "packages/core/node_modules/ajv-formats": {
@@ -15862,6 +15877,13 @@
                     "optional": true
                 }
             }
+        },
+        "packages/core/node_modules/wot-thing-description-types": {
+            "version": "1.1.0-12-March-2025",
+            "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-12-March-2025.tgz",
+            "integrity": "sha512-BRRW4uBATljCPqCbpzNhgY2HFXz8Llh7mAJmjkVimxizOPq8bkmlm0Op/Yv8l7pNQ1GaoBtYwn2BQQjhcQCadA==",
+            "dev": true,
+            "license": "W3C-20150513"
         },
         "packages/examples": {
             "name": "@node-wot/examples",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "tslint": "5.12.1",
         "typescript": "^5.7.3",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.30"
     },
     "version": ""
 }

--- a/packages/binding-coap/package.json
+++ b/packages/binding-coap/package.json
@@ -21,7 +21,7 @@
         "node-coap-client": "1.0.8",
         "rxjs": "5.5.11",
         "slugify": "^1.4.5",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.30"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/binding-modbus/package.json
+++ b/packages/binding-modbus/package.json
@@ -20,7 +20,7 @@
         "@node-wot/core": "0.9.2",
         "modbus-serial": "8.0.17",
         "rxjs": "5.5.11",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.30"
     },
     "scripts": {
         "build": "tsc -b",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
         "@node-wot/binding-mqtt": "0.9.2",
         "@node-wot/binding-websockets": "0.9.2",
         "@node-wot/core": "0.9.2",
-        "@thingweb/thing-model": "^1.0.1",
+        "@thingweb/thing-model": "^1.0.4",
         "ajv": "^8.11.0",
         "commander": "^9.1.0",
         "dotenv": "^16.4.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@petamoriken/float16": "^3.1.1",
-        "@thingweb/thing-model": "^1.0.3",
+        "@thingweb/thing-model": "^1.0.4",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "cbor": "^8.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
         "@types/debug": "^4.1.7",
         "@types/uritemplate": "^0.3.4",
         "@types/uuid": "^8.3.1",
-        "wot-thing-description-types": "^1.1.0-09-November-2023"
+        "wot-thing-description-types": "^1.1.0-12-March-2025"
     },
     "dependencies": {
         "@petamoriken/float16": "^3.1.1",

--- a/packages/examples/src/security/oauth/package.json
+++ b/packages/examples/src/security/oauth/package.json
@@ -19,6 +19,6 @@
         "ts-node": "10.9.1",
         "typescript": "4.7.4",
         "typescript-standard": "^0.3.36",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.29"
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.30"
     }
 }


### PR DESCRIPTION
Note: @thingweb/thing-model needs to be updates first to get a *clean* package-lock.json

fixes https://github.com/eclipse-thingweb/node-wot/issues/1380