### PR TITLE
chore: remove duplicated AJV dependency from binding-opcua and cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15554,8 +15554,6 @@
             "license": "EPL-2.0 OR W3C-20150513",
             "dependencies": {
                 "@node-wot/core": "0.9.2",
-                "ajv": "^8.11.0",
-                "ajv-formats": "^2.1.1",
                 "node-opcua": "2.143.0",
                 "node-opcua-address-space": "2.143.0",
                 "node-opcua-basic-types": "2.139.0",
@@ -15583,23 +15581,6 @@
             },
             "devDependencies": {
                 "should": "^13.2.3"
-            }
-        },
-        "packages/binding-opcua/node_modules/ajv-formats": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
             }
         },
         "packages/binding-websockets": {
@@ -15789,7 +15770,6 @@
                 "@node-wot/binding-mqtt": "0.9.2",
                 "@node-wot/core": "0.9.2",
                 "@thingweb/thing-model": "^1.0.4",
-                "ajv": "^8.11.0",
                 "commander": "^9.1.0",
                 "dotenv": "^16.4.7",
                 "lodash": "^4.17.21",

--- a/packages/binding-opcua/package.json
+++ b/packages/binding-opcua/package.json
@@ -19,8 +19,6 @@
     },
     "dependencies": {
         "@node-wot/core": "0.9.2",
-        "ajv": "^8.11.0",
-        "ajv-formats": "^2.1.1",
         "node-opcua": "2.143.0",
         "node-opcua-address-space": "2.143.0",
         "node-opcua-basic-types": "2.139.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,6 @@
         "@node-wot/binding-mqtt": "0.9.2",
         "@node-wot/core": "0.9.2",
         "@thingweb/thing-model": "^1.0.4",
-        "ajv": "^8.11.0",
         "commander": "^9.1.0",
         "dotenv": "^16.4.7",
         "lodash": "^4.17.21",


### PR DESCRIPTION
fixes https://github.com/eclipse-thingweb/node-wot/issues/1395