### PR TITLE
Avoid external contentType processing for OPC UA

### DIFF
--- a/packages/binding-opcua/src/codec.ts
+++ b/packages/binding-opcua/src/codec.ts
@@ -258,7 +258,7 @@ export const theOpcuaJSONCodec = new OpcuaJSONCodec();
 
 export class OpcuaBinaryCodec implements ContentCodec {
     getMediaType(): string {
-        return "application/opcua+octet-stream"; // see Ege
+        return "application/opcua+octet-stream";
     }
 
     bytesToValue(bytes: Buffer, schema: DataSchema, parameters?: { [key: string]: string }): DataValueJSON {

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -304,7 +304,9 @@ export class OPCUAProtocolClient implements ProtocolClient {
 
     // node-opcua handles the contentType internally and no further *external* processing should be done
     private vanishContentType(form: OPCUAForm) {
-        form.contentType = undefined;
+        if (!(form.contentType === "application/opcua+json" || form.contentType === "application/opcua+octet-stream")) {
+            form.contentType = undefined;
+        }
     }
 
     public async readResource(form: OPCUAForm): Promise<Content> {

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -302,11 +302,13 @@ export class OPCUAProtocolClient implements ProtocolClient {
         return this._resolveNodeId2(form, fNodeId as NodeIdLike | NodeByBrowsePath);
     }
 
+    // node-opcua handles the contentType internally and no further *external* processing should be done
+    private vanishContentType(form: OPCUAForm) {
+        form.contentType = undefined;
+    }
+
     public async readResource(form: OPCUAForm): Promise<Content> {
         debug(`readResource: reading ${form}`);
-
-        // node-opcua handles the contentType internally and no further external processing should be done
-        form.contentType = undefined;
 
         const content = await this._withSession(form, async (session) => {
             const nodeId = await this._resolveNodeId(form);
@@ -317,6 +319,7 @@ export class OPCUAProtocolClient implements ProtocolClient {
             return this._dataValueToContent(form, dataValue);
         });
         debug(`readResource: contentType ${content.type}`);
+        this.vanishContentType(form);
         return content;
     }
 

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -305,6 +305,9 @@ export class OPCUAProtocolClient implements ProtocolClient {
     public async readResource(form: OPCUAForm): Promise<Content> {
         debug(`readResource: reading ${form}`);
 
+        // node-opcua handles the contentType internally and no further external processing should be done
+        form.contentType = undefined;
+
         const content = await this._withSession(form, async (session) => {
             const nodeId = await this._resolveNodeId(form);
             const dataValue = await session.read({


### PR DESCRIPTION
provides a workaround for https://github.com/eclipse-thingweb/node-wot/issues/1400, but does not really fix the issue.
