### PR TITLE
Avoid eslint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,22 +79,22 @@ export default defineConfig([
             // relax missing import rule to warning, as we sometimes have optional dependencies
             // import "../foo" will braise a warning ,
             // import "../foo.js" is the correct way to import a file that may not exist
-            "n/no-missing-import": "warn",
+            "n/no-missing-import": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1428
 
-            "n/no-unsupported-features/node-builtins": "warn",
-            "n/no-extraneous-import": "warn",
-            "n/no-deprecated-api": "warn",
-            "n/no-unpublished-import": "warn",
-            "n/no-process-exit": "warn",
+            "n/no-unsupported-features/node-builtins": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "n/no-extraneous-import": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "n/no-deprecated-api": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "n/no-unpublished-import": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "n/no-process-exit": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
             "n/hashbang": "warn",
 
             // *************** Ensure that only used dependencies are imported ***************
-            "extraneous-dependencies/no-extraneous-dependencies": "warn",
+            "extraneous-dependencies/no-extraneous-dependencies": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
 
             // *************** Code style and best practices ***************
             "unused-imports/no-unused-imports": "error",
             "unused-imports/no-unused-vars": [
-                "warn",
+                "off", // // https://github.com/eclipse-thingweb/node-wot/issues/1430
                 {
                     args: "none",
                     varsIgnorePattern: "Test",
@@ -121,13 +121,13 @@ export default defineConfig([
             "@typescript-eslint/no-use-before-define": "error",
             "@typescript-eslint/no-unused-vars": "off",
             "@typescript-eslint/no-unused-expressions": "off",
-            "@typescript-eslint/no-require-imports": "warn",
-            "@typescript-eslint/prefer-nullish-coalescing": "warn",
-            "@typescript-eslint/no-empty-object-type": "warn",
-            "@typescript-eslint/no-floating-promises": "warn",
+            "@typescript-eslint/no-require-imports": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "@typescript-eslint/prefer-nullish-coalescing": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "@typescript-eslint/no-empty-object-type": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "@typescript-eslint/no-floating-promises": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
 
             // ****************  Enforce usage of `const` over `let` wherever possible, to prevent accidental reassignments
-            "prefer-const": "warn",
+            "prefer-const": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
 
             // *************** Other rules ***************
             "no-restricted-globals": "error",
@@ -135,7 +135,7 @@ export default defineConfig([
 
             "no-use-before-define": "error",
 
-            "no-unused-private-class-members": "warn",
+            "no-unused-private-class-members": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
             "no-prototype-builtins": "off",
             "no-case-declarations": "off",
 

--- a/packages/binding-coap/test/coap-server-test.ts
+++ b/packages/binding-coap/test/coap-server-test.ts
@@ -686,7 +686,6 @@ class CoapServerTest {
                         ).length;
                         const readWriteOpValuePresent = readWriteOpValueCount > 0;
 
-                        // eslint-disable-next-line no-unused-expressions
                         expect(observeOpValuePresent && readWriteOpValuePresent).to.not.be.true;
 
                         if (property.observable !== true) {
@@ -702,16 +701,12 @@ class CoapServerTest {
                 for (const event of Object.values(td.events!)) {
                     for (const form of event.forms) {
                         const opValues = form.op!;
-                        // eslint-disable-next-line no-unused-expressions
                         expect(opValues.length > 0).to.be.true;
 
                         const eventOpValueCount = filterEventOperations(opValues as Array<string>).length;
                         const eventOpValueCountPresent = eventOpValueCount > 0;
 
-                        // eslint-disable-next-line no-unused-expressions
                         expect(eventOpValueCountPresent).to.be.true;
-
-                        // eslint-disable-next-line no-unused-expressions
                         expect(form.subprotocol === "cov:observe").to.be.false;
                     }
                 }

--- a/packages/binding-http/src/credential.ts
+++ b/packages/binding-http/src/credential.ts
@@ -166,11 +166,8 @@ export interface TuyaCustomBearerCredentialConfiguration {
 interface TokenResponse {
     success?: boolean;
     result?: {
-        // eslint-disable-next-line camelcase
         access_token?: string;
-        // eslint-disable-next-line camelcase
         refresh_token?: string;
-        // eslint-disable-next-line camelcase
         expire_time?: number;
     };
 }

--- a/packages/binding-http/src/oauth-token-validation.ts
+++ b/packages/binding-http/src/oauth-token-validation.ts
@@ -47,7 +47,7 @@ interface TokenInformation {
      * Client identifier for the OAuth 2.0 client that
      * requested this token
      */
-    // eslint-disable-next-line camelcase -- the name is defined in the spec
+    // the name is defined in the spec
     client_id?: string;
 }
 

--- a/packages/binding-http/src/routes/properties.ts
+++ b/packages/binding-http/src/routes/properties.ts
@@ -64,7 +64,7 @@ export default async function propertiesRoute(
             res.writeHead(200);
             const recordResponse: Record<string, unknown> = {};
             for (const key of propMap.keys()) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- map key is always present as checked above
+                // map key is always present as checked above
                 const content = propMap.get(key)!;
                 const value = ContentSerdes.get().contentToValue(
                     { type: ContentSerdes.DEFAULT, body: await content.toBuffer() },

--- a/packages/binding-http/src/subscription-protocols.ts
+++ b/packages/binding-http/src/subscription-protocols.ts
@@ -1,4 +1,3 @@
-/* eslint-disable dot-notation -- we are using private functions from HttpClient */
 /********************************************************************************
  * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *

--- a/packages/binding-http/test/http-client-test.ts
+++ b/packages/binding-http/test/http-client-test.ts
@@ -495,9 +495,7 @@ class HttpClientTest2 {
 
         const errorSpy = chai.spy();
         const completeSpy = chai.spy(() => {
-            // eslint-disable-next-line no-unused-expressions
             errorSpy.should.have.been.called.once;
-            // eslint-disable-next-line no-unused-expressions
             completeSpy.should.have.been.called.once;
             done();
         });
@@ -528,9 +526,7 @@ class HttpClientTest2 {
 
         const errorSpy = chai.spy();
         const completeSpy = chai.spy(function () {
-            // eslint-disable-next-line no-unused-expressions
             errorSpy.should.have.been.called.once;
-            // eslint-disable-next-line no-unused-expressions
             completeSpy.should.have.been.called.once;
             done();
             server.close();
@@ -566,9 +562,7 @@ class HttpClientTest2 {
         const subscribeSpy = chai.spy();
 
         const eventSpy = chai.spy(async function (data: Content) {
-            // eslint-disable-next-line no-unused-expressions
             eventSpy.should.have.been.called.once;
-            // eslint-disable-next-line no-unused-expressions
             subscribeSpy.should.have.been.called.once;
             server.close();
             done();
@@ -621,7 +615,6 @@ class HttpClientTest2 {
                         sub.unsubscribe();
                         // wait 100 ms, so that tests fail if unsubscribe didn't work
                         await new Promise((resolve) => setTimeout(resolve, 100));
-                        // eslint-disable-next-line no-unused-expressions
                         eventSpy.should.have.been.called.twice;
                         server.close();
                         done();

--- a/packages/binding-http/test/http-server-oauth-tests.ts
+++ b/packages/binding-http/test/http-server-oauth-tests.ts
@@ -71,23 +71,18 @@ class OAuthServerTests {
     }
 
     @test async "should configure oauth"() {
-        /* eslint-disable dot-notation */
         this.server["supportedSecuritySchemes"].should.contain("oauth2");
         expect(this.server["oAuthValidator"]).to.be.instanceOf(EndpointValidator);
-        /* eslint-enable dot-notation */
     }
 
     @test async "should call oauth validation"() {
         let called = false;
 
-        /* eslint-disable dot-notation */
         expect(this.server["oAuthValidator"]).to.not.be.equal(undefined, "OAuth validator not set");
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.server["oAuthValidator"]!.validate = async (token, scopes, clients) => {
             called = true;
             return true;
         };
-        /* eslint-enable dot-notation */
         await fetch("http://localhost:8080/testoauth/properties/test");
 
         called.should.eql(true);
@@ -96,14 +91,11 @@ class OAuthServerTests {
     @test async "should send unauthorized if oauth validation fails"() {
         let called = false;
 
-        /* eslint-disable dot-notation */
         expect(this.server["oAuthValidator"]).to.not.be.equal(undefined, "OAuth validator not set");
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.server["oAuthValidator"]!.validate = async (token, scopes, clients) => {
             called = true;
             return false;
         };
-        /* eslint-enable dot-notation */
         const response = await fetch("http://localhost:8080/testoauth/properties/test");
 
         called.should.eql(true);
@@ -114,14 +106,11 @@ class OAuthServerTests {
     @test async "should send error if oauth validation throws"() {
         let called = false;
 
-        /* eslint-disable dot-notation */
         expect(this.server["oAuthValidator"]).to.not.be.equal(undefined, "OAuth validator not set");
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.server["oAuthValidator"]!.validate = async (token, scopes, clients) => {
             called = true;
             return false;
         };
-        /* eslint-enable dot-notation */
         const response = await fetch("http://localhost:8080/testoauth/properties/test");
 
         called.should.eql(true);

--- a/packages/binding-http/test/http-server-test.ts
+++ b/packages/binding-http/test/http-server-test.ts
@@ -408,7 +408,6 @@ class HttpServerTest {
 
         await httpServer.start(new Servient());
         expect(httpServer.getPort()).to.eq(port); // port test
-        // eslint-disable-next-line dot-notation
         expect(httpServer["supportedSecuritySchemes"][0]).to.eq("nosec");
         await httpServer.stop();
     }

--- a/packages/binding-mbus/src/mbus-connection.ts
+++ b/packages/binding-mbus/src/mbus-connection.ts
@@ -16,7 +16,6 @@
 import { MBusForm } from "./mbus";
 import { Content, createLoggers } from "@node-wot/core";
 import { Readable } from "stream";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const MbusMaster = require("node-mbus");
 
 const { debug, warn, error } = createLoggers("binding-mbus", "mbus-connection");
@@ -298,7 +297,7 @@ export class PropertyOperation {
      */
     done(
         base?: number,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         result?: any
     ): void {
         debug("Operation done");

--- a/packages/binding-mbus/test/mbus-client-test.ts
+++ b/packages/binding-mbus/test/mbus-client-test.ts
@@ -44,7 +44,6 @@ describe("mbus client test", () => {
             "mbus:unitID": 1,
         };
 
-        // eslint-disable-next-line dot-notation
         client["overrideFormFromURLPath"](form);
         form["mbus:unitID"].should.be.equal(2, "Form value not overridden");
         if (form["mbus:offset"] != null) {

--- a/packages/binding-modbus/src/modbus-client-factory.ts
+++ b/packages/binding-modbus/src/modbus-client-factory.ts
@@ -25,7 +25,7 @@ export default class ModbusClientFactory implements ProtocolClientFactory {
     public getClient(): ProtocolClient {
         debug(`Get client for '${this.scheme}'`);
         this.init();
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- singleton is initialized in init()
+        // singleton is initialized in init()
         return this.singleton!;
     }
 

--- a/packages/binding-modbus/src/modbus-connection.ts
+++ b/packages/binding-modbus/src/modbus-connection.ts
@@ -285,7 +285,7 @@ export class ModbusConnection {
                 // inform and clean up all the operations that the connection cannot be recovered
                 while (this.queue.length > 0) {
                     const transaction = this.queue.shift();
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- queue.length > 0
+                    // queue.length > 0
                     transaction!.operations.forEach((operation) => {
                         operation.failed(error instanceof Error ? error : new Error(JSON.stringify(error)));
                     });
@@ -293,7 +293,7 @@ export class ModbusConnection {
             }
         } else if (this.client.isOpen && this.currentTransaction == null && this.queue.length > 0) {
             // take next transaction from queue and execute
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- queue.length > 0
+            // queue.length > 0
             this.currentTransaction = this.queue.shift()!;
             try {
                 await this.currentTransaction.execute();

--- a/packages/binding-modbus/test/modbus-client-test.ts
+++ b/packages/binding-modbus/test/modbus-client-test.ts
@@ -51,11 +51,9 @@ describe("Modbus client test", () => {
             "modv:entity": "Coil",
         };
 
-        /* eslint-disable dot-notation */
         client["validateAndFillDefaultForm"](form, 0)["modv:function"].should.be.equal(1, "Wrong default read Coil");
         client["validateAndFillDefaultForm"](form, 1)["modv:function"].should.be.equal(5, "Wrong write Coil");
         client["validateAndFillDefaultForm"](form, 2)["modv:function"].should.be.equal(15, "Wrong write multiple Coil");
-        /* eslint-enable dot-notation */
     });
 
     it("use entity alias for holding registries", () => {
@@ -63,7 +61,6 @@ describe("Modbus client test", () => {
             href: "modbus+tcp://127.0.0.1:8502/1/0/?quantity=1",
             "modv:entity": "HoldingRegister",
         };
-        /* eslint-disable dot-notation */
         client["validateAndFillDefaultForm"](form)["modv:function"].should.be.equal(3, "Wrong read Holding register");
         client["validateAndFillDefaultForm"](form, 2)["modv:function"].should.be.equal(
             6,
@@ -73,7 +70,6 @@ describe("Modbus client test", () => {
             16,
             "Wrong write multiple Holding register"
         );
-        /* eslint-enable dot-notation */
     });
 
     it("use entity alias for other entities", () => {
@@ -81,11 +77,9 @@ describe("Modbus client test", () => {
             href: "modbus+tcp://127.0.0.1:8502/1/0?quantity=1",
             "modv:entity": "DiscreteInput",
         };
-        /* eslint-disable dot-notation */
         client["validateAndFillDefaultForm"](form)["modv:function"].should.be.equal(2, "Wrong read Discrete input");
         form["modv:entity"] = "InputRegister";
         client["validateAndFillDefaultForm"](form)["modv:function"].should.be.equal(4, "Wrong read Input register");
-        /* eslint-enable dot-notation */
     });
 
     it("should convert function names", () => {
@@ -94,7 +88,6 @@ describe("Modbus client test", () => {
             "modv:function": "readCoil",
         };
 
-        // eslint-disable-next-line dot-notation
         client["validateAndFillDefaultForm"](form)["modv:function"].should.be.equal(1, "Wrong substitution");
     });
 
@@ -104,7 +97,6 @@ describe("Modbus client test", () => {
             "modv:function": "readCoil",
         };
 
-        // eslint-disable-next-line dot-notation
         const result = client["validateAndFillDefaultForm"](form);
         result["modv:unitID"].should.be.equal(2, "unitID  value not set");
         result["modv:address"].should.be.equal(2, "address value not set");
@@ -117,7 +109,6 @@ describe("Modbus client test", () => {
             "modv:function": "readCoil",
         };
 
-        // eslint-disable-next-line dot-notation
         const result = client["validateAndFillDefaultForm"](form);
         result["modv:unitID"].should.be.equal(2, "unitID  value not set");
         result["modv:address"].should.be.equal(2, "address value not set");

--- a/packages/binding-modbus/test/modbus-connection-test.ts
+++ b/packages/binding-modbus/test/modbus-connection-test.ts
@@ -39,7 +39,6 @@ describe("Modbus connection", () => {
     it("should connect", async () => {
         const connection = new ModbusConnection("127.0.0.1", 8502);
         await connection.connect();
-        // eslint-disable-next-line no-unused-expressions
         connection.client.isOpen.should.be.true;
     });
 

--- a/packages/binding-mqtt/src/mqtt-broker-server.ts
+++ b/packages/binding-mqtt/src/mqtt-broker-server.ts
@@ -405,9 +405,7 @@ export default class MqttBrokerServer implements ProtocolServer {
         if (this.hostedBroker !== undefined) {
             // When the broker is hosted, we need to close it.
             // Both this.hostedBroker and this.hostedServer are defined at the same time.
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             await new Promise<void>((resolve) => this.hostedServer!.close(() => resolve()));
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             await new Promise<void>((resolve) => this.hostedBroker!.close(() => resolve()));
         }
     }

--- a/packages/binding-mqtt/src/mqtts-client-factory.ts
+++ b/packages/binding-mqtt/src/mqtts-client-factory.ts
@@ -27,7 +27,6 @@ export default class MqttsClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "mqtts";
     private readonly clients: Array<ProtocolClient> = [];
 
-    // eslint-disable-next-line no-useless-constructor
     constructor(private readonly config: MqttClientConfig) {}
     getClient(): ProtocolClient {
         const client = new MqttClient(this.config, true);

--- a/packages/binding-netconf/src/xpath2json.ts
+++ b/packages/binding-netconf/src/xpath2json.ts
@@ -17,7 +17,7 @@ export function isPlainObject(a: unknown): boolean {
     return typeof a === "object" && a !== null && !Array.isArray(a) && !(a instanceof Date);
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function json2xpath(json: any, index: number, str: Array<string>): string[] {
     if (!isPlainObject(json)) {
         return str;

--- a/packages/binding-websockets/src/ws-client.ts
+++ b/packages/binding-websockets/src/ws-client.ts
@@ -23,7 +23,6 @@ import { Subscription } from "rxjs/Subscription";
 const { debug, warn } = createLoggers("binding-websockets", "ws-client");
 
 export default class WebSocketClient implements ProtocolClient {
-    // eslint-disable-next-line no-useless-constructor
     constructor() {
         // TODO: implement and remove eslint-ignore-useless-constructor
     }

--- a/packages/binding-websockets/src/wss-client-factory.ts
+++ b/packages/binding-websockets/src/wss-client-factory.ts
@@ -22,7 +22,6 @@ import { ProtocolClientFactory, ProtocolClient } from "@node-wot/core";
 export default class WssClientFactory implements ProtocolClientFactory {
     public readonly scheme: string = "wss";
 
-    // eslint-disable-next-line no-useless-constructor
     constructor() {
         // TODO: implement and remove eslint-ignore-useless-constructor
     }

--- a/packages/cli/src/cli-default-servient.ts
+++ b/packages/cli/src/cli-default-servient.ts
@@ -87,7 +87,6 @@ export default class DefaultServient extends Servient {
     // current log level
     public logLevel = "info";
 
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     public constructor(clientOnly: boolean, config?: any) {
         super();
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /********************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
@@ -252,7 +251,6 @@ async function buildConfig(): Promise<unknown> {
 }
 const loadCompilerFunction = function (compilerModule: string | undefined) {
     if (compilerModule != null) {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
         const compilerMod = require(compilerModule);
 
         if (compilerMod.create == null) {
@@ -308,7 +306,6 @@ const runScripts = async function (servient: DefaultServient, scripts: Array<str
         });
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     if (debug && debug.shouldBreak) {
         // Activate inspector only if is not already opened and wait for the debugger to attach
         inspector.url() == null && inspector.open(debug.port, debug.host, true);

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -157,7 +157,6 @@ class InternalPropertySubscription extends InternalSubscription {
 
     async stop(options?: WoT.InteractionOptions): Promise<void> {
         await this.unobserveProperty(options);
-        // eslint-disable-next-line dot-notation
         this.thing["observedProperties"].delete(this.name);
     }
 
@@ -289,7 +288,6 @@ class InternalEventSubscription extends InternalSubscription {
 
     async stop(options?: WoT.InteractionOptions): Promise<void> {
         await this.unsubscribeEvent(options);
-        // eslint-disable-next-line dot-notation
         this.thing["subscribedEvents"].delete(this.name);
     }
 
@@ -559,7 +557,7 @@ export default class ConsumedThing extends Thing implements IConsumedThing {
             if (cacheIdx !== -1) {
                 // from cache
                 debug(`ConsumedThing '${this.title}' chose cached client for '${schemes[cacheIdx]}'`);
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- if cacheIdx is valid, then clients *contains* schemes[cacheIdx]
+                // if cacheIdx is valid, then clients *contains* schemes[cacheIdx]
                 client = this.#clients.get(schemes[cacheIdx])!;
                 form = this.findForm(forms, op, affordance, schemes, cacheIdx);
             } else {

--- a/packages/core/src/content-serdes.ts
+++ b/packages/core/src/content-serdes.ts
@@ -147,7 +147,7 @@ export class ContentSerdes {
             const codec = this.codecs.get(mt);
 
             // use codec to deserialize
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- this.codecs.has(mt) is true
+            // this.codecs.has(mt) is true
             const res = codec!.bytesToValue(content.body, schema, par);
 
             return res;

--- a/packages/core/src/protocol-helpers.ts
+++ b/packages/core/src/protocol-helpers.ts
@@ -356,16 +356,16 @@ export default class ProtocolHelpers {
         if (interaction.forms !== undefined && finalFormIndex === -1) {
             if (operationName !== undefined) {
                 interaction.forms.every((form: Form) => {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- operationName !== undefined
+                    // operationName !== undefined
                     if (form.op?.includes(operationName!) === true) {
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- interaction.forms  !== undefined
+                        // interaction.forms  !== undefined
                         finalFormIndex = interaction.forms!.indexOf(form);
                     }
                     return finalFormIndex === -1;
                 });
             } else {
                 interaction.forms.every((form: Form) => {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- interaction.forms  !== undefined
+                    // interaction.forms  !== undefined
                     finalFormIndex = interaction.forms!.indexOf(form);
                     return false;
                 });

--- a/packages/core/test/client-test.ts
+++ b/packages/core/test/client-test.ts
@@ -382,7 +382,6 @@ class WoTClientTest {
         expect(thing.getThingDescription()).to.have.property("properties").to.have.property("aProperty");
 
         const result = await thing.readProperty("aProperty");
-        // eslint-disable-next-line no-unused-expressions
         expect(result).not.to.be.null;
 
         const value = await result.value();
@@ -402,11 +401,8 @@ class WoTClientTest {
         expect(thing.getThingDescription()).to.have.property("properties").to.have.property("aProperty");
 
         const result: WoT.PropertyReadMap = await thing.readAllProperties();
-        // eslint-disable-next-line no-unused-expressions
         expect(result).not.to.be.null;
-        // eslint-disable-next-line no-unused-expressions
         expect(result.get("aProperty")).not.to.be.null;
-        // eslint-disable-next-line no-unused-expressions
         expect(result.get("aPropertyToObserve")).to.be.undefined;
 
         const io = result.get("aProperty");
@@ -485,7 +481,6 @@ class WoTClientTest {
         expect(thing).to.have.property("title").that.equals("aThing");
         expect(thing).to.have.property("actions").that.has.property("anAction");
         const result = await thing.invokeAction("anAction", 23);
-        // eslint-disable-next-line no-unused-expressions
         expect(result).not.to.be.null;
         const value = await result?.value();
         expect(value).to.equal(42);
@@ -504,7 +499,6 @@ class WoTClientTest {
         expect(thing).to.have.property("title").that.equals("aThing");
         expect(thing).to.have.property("actions").that.has.property("anAction");
         const result = await thing.invokeAction("anAction", 23);
-        // eslint-disable-next-line no-unused-expressions
         expect(result).not.to.be.null;
         const value = await result?.value();
         expect(value).to.equal(42);
@@ -548,7 +542,6 @@ class WoTClientTest {
 
         // deal with ActionStatus object
         const result = await thing.invokeAction("anAsyncAction", 23);
-        // eslint-disable-next-line no-unused-expressions
         expect(result).not.to.be.null;
         const value = await result?.value();
         expect(value).to.have.property("status");
@@ -784,7 +777,6 @@ class WoTClientTest {
         const thing = await WoTClientTest.WoT.consume(td);
 
         const result = await thing.readProperty("aProperty", { uriVariables: { idTest: "test" } });
-        // eslint-disable-next-line no-unused-expressions
         expect(result).not.to.be.null;
 
         const value = await result.value();
@@ -801,14 +793,11 @@ class WoTClientTest {
 
     @test async "adding and removing client factory"() {
         const tcf2 = new TrapClientFactory2();
-        // eslint-disable-next-line no-unused-expressions
         expect(WoTClientTest.servient.hasClientFor(tcf2.scheme)).to.be.not.true;
         WoTClientTest.servient.addClientFactory(new TrapClientFactory2());
-        // eslint-disable-next-line no-unused-expressions
         expect(WoTClientTest.servient.hasClientFor(tcf2.scheme)).to.be.true;
         const result = WoTClientTest.servient.removeClientFactory(tcf2.scheme);
         expect(result);
-        // eslint-disable-next-line no-unused-expressions
         expect(WoTClientTest.servient.hasClientFor(tcf2.scheme)).to.be.not.true;
     }
 

--- a/packages/core/test/helpers-test.ts
+++ b/packages/core/test/helpers-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 /********************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *

--- a/packages/core/test/interaction-output-test.ts
+++ b/packages/core/test/interaction-output-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 /********************************************************************************
  * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
@@ -48,7 +47,7 @@ class InteractionOutputTests {
         expect(reader).not.to.be.undefined;
         let read;
         do {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know it's defined: expect(reader).not.to.be.undefined
+            // we know it's defined: expect(reader).not.to.be.undefined
             read = await reader!.read();
             !read.done && result.push(read.value);
         } while (read.done !== true);
@@ -66,7 +65,7 @@ class InteractionOutputTests {
         expect(reader).not.to.be.undefined;
         let read;
         do {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know it's defined: expect(reader).not.to.be.undefined
+            // we know it's defined: expect(reader).not.to.be.undefined
             read = await reader!.read();
             !read.done && result.push(read.value);
         } while (read.done !== true);

--- a/packages/core/test/protocol-helpers-stream-test.ts
+++ b/packages/core/test/protocol-helpers-stream-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 /********************************************************************************
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *

--- a/packages/core/test/protocol-helpers-test.ts
+++ b/packages/core/test/protocol-helpers-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 /********************************************************************************
  * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *

--- a/packages/core/test/server-test.ts
+++ b/packages/core/test/server-test.ts
@@ -89,7 +89,6 @@ class WoTServerTest {
             },
         });
 
-        // eslint-disable-next-line no-unused-expressions
         expect(thing).to.exist;
         // round-trip
         expect(thing.getThingDescription()).to.have.property("title").that.equals("myFragmentThing");
@@ -881,9 +880,7 @@ class WoTServerTest {
         });
 
         const protocolListener = spy(async (content: Content) => {
-            // eslint-disable-next-line no-unused-expressions
             expect(content.type).not.to.be.undefined;
-            // eslint-disable-next-line no-unused-expressions
             expect(content.body).not.to.be.undefined;
 
             const body = await content.toBuffer();

--- a/packages/examples/src/testthing/testthing.ts
+++ b/packages/examples/src/testthing/testthing.ts
@@ -273,7 +273,6 @@ WoT.produce({
                 }
 
                 if (inputtype === "number") {
-                    // eslint-disable-next-line no-new-wrappers
                     return new String(localParameters)
                         .replace(/0/g, "zero-")
                         .replace(/1/g, "one-")


### PR DESCRIPTION
By
* turning off some warnings
* fix warnings like unused eslint-disable directive by removing useless command 

see https://github.com/eclipse-thingweb/node-wot/issues/1430