### PR TITLE
refactor: activate eslint @typescript-eslint/no-require-imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,7 +121,7 @@ export default defineConfig([
             "@typescript-eslint/no-use-before-define": "error",
             "@typescript-eslint/no-unused-vars": "off",
             "@typescript-eslint/no-unused-expressions": "off",
-            "@typescript-eslint/no-require-imports": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
+            "@typescript-eslint/no-require-imports": "error",
             "@typescript-eslint/prefer-nullish-coalescing": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
             "@typescript-eslint/no-empty-object-type": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430
             "@typescript-eslint/no-floating-promises": "off", // https://github.com/eclipse-thingweb/node-wot/issues/1430

--- a/packages/binding-coap/src/mdns-introducer.ts
+++ b/packages/binding-coap/src/mdns-introducer.ts
@@ -13,6 +13,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
  ********************************************************************************/
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 import makeMdns = require("multicast-dns");
 import { networkInterfaces } from "os";
 import { MulticastDNS } from "multicast-dns";

--- a/packages/binding-mbus/src/mbus-connection.ts
+++ b/packages/binding-mbus/src/mbus-connection.ts
@@ -16,7 +16,7 @@
 import { MBusForm } from "./mbus";
 import { Content, createLoggers } from "@node-wot/core";
 import { Readable } from "stream";
-const MbusMaster = require("node-mbus");
+import * as MbusMaster from "node-mbus";
 
 const { debug, warn, error } = createLoggers("binding-mbus", "mbus-connection");
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,7 +18,7 @@ import DefaultServient from "./cli-default-servient";
 import ErrnoException = NodeJS.ErrnoException;
 
 // tools
-import fs = require("fs");
+import * as fs from "fs";
 import * as dotenv from "dotenv";
 import * as path from "path";
 import { Command, InvalidArgumentError, Argument } from "commander";
@@ -251,6 +251,7 @@ async function buildConfig(): Promise<unknown> {
 }
 const loadCompilerFunction = function (compilerModule: string | undefined) {
     if (compilerModule != null) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
         const compilerMod = require(compilerModule);
 
         if (compilerMod.create == null) {

--- a/packages/core/src/consumed-thing.ts
+++ b/packages/core/src/consumed-thing.ts
@@ -39,7 +39,7 @@ import ContentType from "content-type";
 
 import ContentManager from "./content-serdes";
 
-import UriTemplate = require("uritemplate");
+import * as UriTemplate from "uritemplate";
 import { InteractionOutput, ActionInteractionOutput } from "./interaction-output";
 import {
     ActionElement,

--- a/packages/core/src/serdes.ts
+++ b/packages/core/src/serdes.ts
@@ -17,8 +17,9 @@ import { Thing } from "./thing-description";
 import * as TD from "./thing-description";
 import { createLoggers } from "./logger";
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 import isAbsoluteUrl = require("is-absolute-url");
-import URLToolkit = require("url-toolkit");
+import * as URLToolkit from "url-toolkit";
 import {
     ThingContext,
     PropertyElement,

--- a/packages/core/test/helpers-test.ts
+++ b/packages/core/test/helpers-test.ts
@@ -27,7 +27,7 @@ import * as TDT from "wot-thing-description-types";
 
 import Helpers from "../src/helpers";
 
-import UriTemplate = require("uritemplate");
+import * as UriTemplate from "uritemplate";
 
 @suite("tests to verify the helpers")
 class HelperTest {


### PR DESCRIPTION
some need to stay because of usage/limitations

see https://github.com/eclipse-thingweb/node-wot/issues/1430