### PR TITLE
Add Node.js version 26.x to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest, windows-2022]
-                node-version: [22.x, 24.x]
+                node-version: [22.x, 24.x, 26.x]
 
         timeout-minutes: 30
 


### PR DESCRIPTION
fixes https://github.com/eclipse-thingweb/node-wot/issues/1532