### PR TITLE
fix(binding-opcua) opcua security #1401

### DIFF
--- a/packages/binding-opcua/README.md
+++ b/packages/binding-opcua/README.md
@@ -177,19 +177,20 @@ As an extension beyond the specification, the binding also accepts any other pol
 
 ### Authentication — `uav:authentication`
 
-| `uav:userIdentityToken` | additional properties                             |
-| ----------------------- | ------------------------------------------------- |
-| `"Anonymous"`           | none                                              |
-| `"UserName"`            | `userName` (required), `password`                 |
-| `"Certificate"`         | `certificate` (required, PEM), `privateKey` (PEM) |
+| `uav:userIdentityToken` | credentials required                    |
+| ----------------------- | --------------------------------------- |
+| `"Anonymous"`           | none                                    |
+| `"UserName"`            | `{ userName, password }`                |
+| `"Certificate"`         | `{ certificate, privateKey }`, both PEM |
+
+The scheme says only _which kind_ of identity to use. The identity itself is never written in the
+thing description — see [Credentials](#credentials) below.
 
 ```javascript
 securityDefinitions: {
     user_sc: {
         scheme: "uav:authentication",
         "uav:userIdentityToken": "UserName",
-        userName: "joe",
-        password: "secret",
     },
 },
 security: "user_sc",
@@ -200,13 +201,28 @@ as `oauth2` — are defined by OPC 10101 and are recognised by the binding, but 
 `node-opcua` does not support issued tokens yet, so a thing description requesting one is refused
 with an explicit error rather than connected under a weaker identity.
 
-> **Deviation from OPC 10101.** The specification states that login credentials such as user names,
-> passwords and certificates are _not_ shared in thing descriptions and must be provided
-> separately, e.g. through a credential store or by prompting the user. Its own examples therefore
-> declare `uav:userIdentityToken` and nothing else. This binding has no credential store yet, so
-> the `userName`, `password`, `certificate` and `privateKey` properties above are read from the
-> thing description itself. That is an extension, and it means a thing description carrying
-> credentials is a secret: do not publish or share one.
+### Credentials
+
+OPC 10101 §6.3.2 and §6.3.3 both state that login credentials are _not_ shared in thing
+descriptions and must be provided separately. They are therefore registered with the servient,
+keyed by the **thing id**:
+
+```javascript
+const servient = new Servient();
+servient.addClientFactory(new OPCUAClientFactory());
+servient.addCredentials({
+    "urn:my-opcua-thing": { userName: "joe", password: "secret" },
+});
+```
+
+For a `Certificate` scheme, supply `{ certificate, privateKey }` instead, both in PEM form. When
+several credentials are registered for one thing, the binding selects the entry that fits the
+scheme, so a user name and a certificate may coexist.
+
+A scheme whose credentials are missing is an error: the connection is refused rather than
+downgraded to an anonymous session.
+
+Since the thing description no longer carries any secret, it can be published and shared freely.
 
 ### Combining the two schemes
 
@@ -223,8 +239,6 @@ securityDefinitions: {
     user_sc: {
         scheme: "uav:authentication",
         "uav:userIdentityToken": "UserName",
-        userName: "joe",
-        password: "secret",
     },
     secure_sc: {
         scheme: "combo",
@@ -273,13 +287,23 @@ being silently ignored and connected without security.
 | `"tokenType": "anonymous"` / `"username"` / `"certificate"` | `"uav:userIdentityToken": "Anonymous"` / `"UserName"` / `"Certificate"` |
 | `"scheme": "uav:authentication"`                            | unchanged                                                               |
 
-The `userName`, `password`, `certificate` and `privateKey` properties are unchanged.
+Credentials that used to sit inside the authentication scheme — `userName`, `password`,
+`certificate`, `privateKey` — move out of the thing description entirely; see
+[Credentials](#credentials).
 
 ## Advanced
 
 The OPC-UA binding for node-wot offers additional features to allow you to interact with
 OPCUA Variant and DataValue in OPCUA JSON encoded form.
 For an example of use, you can dive into the unit test of the binding-opcua library.
+
+### A worked security example
+
+`packages/binding-opcua/test/opcua-security-e2e-test.ts` is a narrated tour of the security
+schemes against a real OPC UA server. Each case builds one thing description, connects, and then
+asks the server what session it actually granted — so it shows what happened on the wire rather
+than what was requested. `packages/examples/src/bindings/opcua/demo-opcua-secure.ts` is the same
+thing as a runnable script.
 
 ### Exploring the unit tests
 

--- a/packages/binding-opcua/README.md
+++ b/packages/binding-opcua/README.md
@@ -104,6 +104,177 @@ const thingDescription = {
 };
 ```
 
+## Security
+
+The security schemes accepted by this binding are those defined in
+[OPC 10101 "OPC UA for WoT Binding"](https://reference.opcfoundation.org/specs/OPC-10101) §6.3.
+There are three ways to describe an OPC UA connection:
+
+-   `nosec` (§6.3.1) — the server has a single endpoint with no security at all.
+-   `auto` (§6.3.2) — the server offers several endpoints, and the client selects one at
+    connection time. See [Letting the binding choose](#letting-the-binding-choose--auto).
+-   `uav:channelsec` and `uav:authentication` (§6.3.3) — the thing description states explicitly
+    which security settings to use.
+
+The last of these is two schemes rather than one, because OPC UA has two independent security
+layers:
+
+-   **channel security** (`uav:channelsec`) protects the _connection_ — whether messages are
+    signed and/or encrypted, and with which cryptographic suite.
+-   **authentication** (`uav:authentication`) identifies _who_ is connecting.
+
+The two are orthogonal: an encrypted channel may carry an anonymous user, and a named user may
+connect over a plain text channel. A thing description that needs both combines them with a
+`combo` scheme, as shown further down.
+
+Both schemes use the `uav` prefix, which must be bound in the `@context` of the thing description:
+
+```javascript
+const thingDescription = {
+    "@context": ["https://www.w3.org/2019/wot/td/v1", { uav: "http://opcfoundation.org/UA/WoT-Binding/" }],
+    // ...
+};
+```
+
+### Channel security — `uav:channelsec`
+
+| property             | value                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `uav:securityMode`   | `"None"`, `"Sign"` or `"SignAndEncrypt"`                                                              |
+| `uav:securityPolicy` | the cryptographic suite, e.g. `"Basic256Sha256"`, `"Aes128_Sha256_RsaOaep"`, `"Aes256_Sha256_RsaPss"` |
+
+Both terms are required by the specification. When `uav:securityMode` is `"None"` the policy
+carries no information; this binding accepts `"uav:securityPolicy": "None"` and also tolerates its
+absence. Conversely, `"None"` is refused when the mode asks for security, since it cannot satisfy
+it. The policy may be written either as its short name, as above, or as its full URI
+(`"http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256"`), the latter being an extension.
+
+A value of `uav:securityMode` or `uav:userIdentityToken` outside the set the specification defines
+is an error, and the connection is refused. It is never treated as an unspecified default, which
+would connect with less security than the thing description asked for.
+
+```javascript
+securityDefinitions: {
+    channel_sc: {
+        scheme: "uav:channelsec",
+        "uav:securityMode": "SignAndEncrypt",
+        "uav:securityPolicy": "Basic256Sha256",
+    },
+},
+security: "channel_sc",
+```
+
+OPC 10101 names `None`, `Basic256Sha256`, `Aes128_Sha256_RsaOaep` and `Aes256_Sha256_RsaPss` as
+the policies to use, and lists `Basic256` and `Basic128Rsa15` as outdated and not recommended.
+Those two are deliberately left out of the TypeScript type, so a thing description written in
+TypeScript will not compile if it uses them; they are not rejected at runtime, so a plain JSON
+thing description may still request one and will connect. Do not rely on this, and prefer
+`Basic256Sha256` or better.
+
+As an extension beyond the specification, the binding also accepts any other policy known to
+`node-opcua` — `Basic128`, `Basic192`, `Basic192Rsa15`, `Basic256Rsa15`. These are outside OPC
+10101, so a thing description using them is not portable to another binding.
+
+### Authentication — `uav:authentication`
+
+| `uav:userIdentityToken` | additional properties                             |
+| ----------------------- | ------------------------------------------------- |
+| `"Anonymous"`           | none                                              |
+| `"UserName"`            | `userName` (required), `password`                 |
+| `"Certificate"`         | `certificate` (required, PEM), `privateKey` (PEM) |
+
+```javascript
+securityDefinitions: {
+    user_sc: {
+        scheme: "uav:authentication",
+        "uav:userIdentityToken": "UserName",
+        userName: "joe",
+        password: "secret",
+    },
+},
+security: "user_sc",
+```
+
+`"IssuedToken"` and its companion term `uav:issueToken` — which references a separate scheme such
+as `oauth2` — are defined by OPC 10101 and are recognised by the binding, but cannot be used:
+`node-opcua` does not support issued tokens yet, so a thing description requesting one is refused
+with an explicit error rather than connected under a weaker identity.
+
+> **Deviation from OPC 10101.** The specification states that login credentials such as user names,
+> passwords and certificates are _not_ shared in thing descriptions and must be provided
+> separately, e.g. through a credential store or by prompting the user. Its own examples therefore
+> declare `uav:userIdentityToken` and nothing else. This binding has no credential store yet, so
+> the `userName`, `password`, `certificate` and `privateKey` properties above are read from the
+> thing description itself. That is an extension, and it means a thing description carrying
+> credentials is a secret: do not publish or share one.
+
+### Combining the two schemes
+
+Because channel security and authentication are separate schemes, a thing description that needs
+both declares each one and joins them with a `combo` scheme, as OPC 10101 §6.3.3 prescribes:
+
+```javascript
+securityDefinitions: {
+    channel_sc: {
+        scheme: "uav:channelsec",
+        "uav:securityMode": "SignAndEncrypt",
+        "uav:securityPolicy": "Basic256Sha256",
+    },
+    user_sc: {
+        scheme: "uav:authentication",
+        "uav:userIdentityToken": "UserName",
+        userName: "joe",
+        password: "secret",
+    },
+    secure_sc: {
+        scheme: "combo",
+        allOf: ["channel_sc", "user_sc"],
+    },
+},
+security: "secure_sc",
+```
+
+A scheme declared on its own leaves the other layer at its default, which is the least privileged
+one: `uav:channelsec` alone connects anonymously, and `uav:authentication` alone connects over an
+unsecured channel.
+
+OPC 10101 only uses `allOf` here. This binding also accepts a `combo` scheme using `oneOf`, in
+which case the first alternative is selected; that is an extension beyond the specification.
+
+### Letting the binding choose — `auto`
+
+`"scheme": "auto"` is the AutoSecurityScheme of OPC 10101 §6.3.2, and is the specification's
+recommendation when the server exposes several endpoints with different settings. The client
+executes the OPC UA `GetEndpoints` service and selects an endpoint from what the server advertises;
+this binding picks the most secure channel on offer. It settles channel security only, so it is
+normally combined with a `uav:authentication` scheme:
+
+```javascript
+securityDefinitions: {
+    auto_sc: { scheme: "auto" },
+    anonymous_sc: { scheme: "uav:authentication", "uav:userIdentityToken": "Anonymous" },
+    secure_sc: { scheme: "combo", allOf: ["auto_sc", "anonymous_sc"] },
+},
+security: "secure_sc",
+```
+
+### Migrating from 0.9.2
+
+Version 0.9.2 shipped provisional names, invented before OPC 10101 was published. They have been
+replaced by the names the specification defines, and the old ones are no longer accepted — a thing
+description that still uses them is rejected with an error naming its replacement, rather than
+being silently ignored and connected without security.
+
+| 0.9.2                                                       | OPC 10101 v1.00                                                         |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `"scheme": "uav:channel-security"`                          | `"scheme": "uav:channelsec"`                                            |
+| `"messageMode": "none"` / `"sign"` / `"sign_encrypt"`       | `"uav:securityMode": "None"` / `"Sign"` / `"SignAndEncrypt"`            |
+| `"policy": "..."`                                           | `"uav:securityPolicy": "..."`                                           |
+| `"tokenType": "anonymous"` / `"username"` / `"certificate"` | `"uav:userIdentityToken": "Anonymous"` / `"UserName"` / `"Certificate"` |
+| `"scheme": "uav:authentication"`                            | unchanged                                                               |
+
+The `userName`, `password`, `certificate` and `privateKey` properties are unchanged.
+
 ## Advanced
 
 The OPC-UA binding for node-wot offers additional features to allow you to interact with

--- a/packages/binding-opcua/README.md
+++ b/packages/binding-opcua/README.md
@@ -276,8 +276,8 @@ security: "secure_sc",
 
 Version 0.9.2 shipped provisional names, invented before OPC 10101 was published. They have been
 replaced by the names the specification defines, and the old ones are no longer accepted — a thing
-description that still uses them is rejected with an error naming its replacement, rather than
-being silently ignored and connected without security.
+description that still uses them is rejected with an error, rather than being silently ignored and
+connected without security. Use the table below to migrate.
 
 | 0.9.2                                                       | OPC 10101 v1.00                                                         |
 | ----------------------------------------------------------- | ----------------------------------------------------------------------- |

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -525,8 +525,8 @@ export class OPCUAProtocolClient implements ProtocolClient {
         return true;
     }
 
-    #setAuthentication(security: OPCUACAuthenticationScheme): boolean {
-        this._userIdentity = resolvedUserIdentity(security);
+    #setAuthentication(security: OPCUACAuthenticationScheme, credentials?: unknown): boolean {
+        this._userIdentity = resolvedUserIdentity(security, credentials);
         return true;
     }
 
@@ -552,7 +552,7 @@ export class OPCUAProtocolClient implements ProtocolClient {
                     success = this.#setChannelSecurity(securityScheme as OPCUAChannelSecurityScheme);
                     break;
                 case "uav:authentication":
-                    success = this.#setAuthentication(securityScheme as OPCUACAuthenticationScheme);
+                    success = this.#setAuthentication(securityScheme as OPCUACAuthenticationScheme, credentials);
                     break;
                 case "combo": {
                     const combo = securityScheme as AllOfSecurityScheme | OneOfSecurityScheme;

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -63,7 +63,7 @@ import { Argument, MessageSecurityMode, UserTokenType } from "node-opcua-types";
 import { isGoodish2 } from "node-opcua";
 
 import { schemaDataValue } from "./codecs/opcua-data-schemas";
-import { OPCUACAuthenticationScheme, OPCUAChannelSecurityScheme } from "./security-scheme";
+import { DEPRECATED_SCHEME_NAMES, OPCUACAuthenticationScheme, OPCUAChannelSecurityScheme } from "./security-scheme";
 import { CertificateManagerSingleton } from "./certificate-manager-singleton";
 import { resolveChannelSecurity, resolvedUserIdentity } from "./opcua-security-resolver";
 import { findMostSecureChannel } from "./find-most-secure-channel";
@@ -548,7 +548,7 @@ export class OPCUAProtocolClient implements ProtocolClient {
                     success = true;
                     break;
                 }
-                case "uav:channel-security":
+                case "uav:channelsec":
                     success = this.#setChannelSecurity(securityScheme as OPCUAChannelSecurityScheme);
                     break;
                 case "uav:authentication":
@@ -567,18 +567,26 @@ export class OPCUAProtocolClient implements ProtocolClient {
                     }
                     break;
                 }
-                default:
-                    // A scheme from another binding is legitimately none of our
-                    // business. One in our own namespace is: ignoring it would
-                    // connect with the insecure defaults and report success.
+                default: {
+                    const replacement = DEPRECATED_SCHEME_NAMES[securityScheme.scheme];
+                    if (replacement !== undefined) {
+                        // A pre-OPC-10101 name. Refuse rather than ignore: ignoring it would
+                        // connect with the insecure defaults while reporting success. (#1401)
+                        throw new Error(
+                            `Security scheme '${securityScheme.scheme}' is no longer supported. ` +
+                                `Use '${replacement}' instead, with the property names defined by ` +
+                                `OPC 10101 v1.00 ("uav:securityMode", "uav:securityPolicy", "uav:userIdentityToken").`
+                        );
+                    }
                     if (securityScheme.scheme?.startsWith("uav:")) {
                         throw new Error(
                             `Unsupported OPC UA security scheme '${securityScheme.scheme}'. ` +
-                                `Supported schemes are 'uav:channel-security' and 'uav:authentication'.`
+                                `Supported schemes are 'uav:channelsec' and 'uav:authentication'.`
                         );
                     }
                     // not for us , ignored
                     break;
+                }
             }
             if (!success) return false;
         }

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -568,6 +568,15 @@ export class OPCUAProtocolClient implements ProtocolClient {
                     break;
                 }
                 default:
+                    // A scheme from another binding is legitimately none of our
+                    // business. One in our own namespace is: ignoring it would
+                    // connect with the insecure defaults and report success.
+                    if (securityScheme.scheme?.startsWith("uav:")) {
+                        throw new Error(
+                            `Unsupported OPC UA security scheme '${securityScheme.scheme}'. ` +
+                                `Supported schemes are 'uav:channel-security' and 'uav:authentication'.`
+                        );
+                    }
                     // not for us , ignored
                     break;
             }

--- a/packages/binding-opcua/src/opcua-protocol-client.ts
+++ b/packages/binding-opcua/src/opcua-protocol-client.ts
@@ -63,7 +63,7 @@ import { Argument, MessageSecurityMode, UserTokenType } from "node-opcua-types";
 import { isGoodish2 } from "node-opcua";
 
 import { schemaDataValue } from "./codecs/opcua-data-schemas";
-import { DEPRECATED_SCHEME_NAMES, OPCUACAuthenticationScheme, OPCUAChannelSecurityScheme } from "./security-scheme";
+import { OPCUACAuthenticationScheme, OPCUAChannelSecurityScheme } from "./security-scheme";
 import { CertificateManagerSingleton } from "./certificate-manager-singleton";
 import { resolveChannelSecurity, resolvedUserIdentity } from "./opcua-security-resolver";
 import { findMostSecureChannel } from "./find-most-secure-channel";
@@ -568,16 +568,9 @@ export class OPCUAProtocolClient implements ProtocolClient {
                     break;
                 }
                 default: {
-                    const replacement = DEPRECATED_SCHEME_NAMES[securityScheme.scheme];
-                    if (replacement !== undefined) {
-                        // A pre-OPC-10101 name. Refuse rather than ignore: ignoring it would
-                        // connect with the insecure defaults while reporting success. (#1401)
-                        throw new Error(
-                            `Security scheme '${securityScheme.scheme}' is no longer supported. ` +
-                                `Use '${replacement}' instead, with the property names defined by ` +
-                                `OPC 10101 v1.00 ("uav:securityMode", "uav:securityPolicy", "uav:userIdentityToken").`
-                        );
-                    }
+                    // A scheme in our own namespace that we cannot honour is an error: ignoring it
+                    // would connect with the insecure defaults while reporting success. This also
+                    // covers the pre-OPC-10101 names, such as "uav:channel-security". (#1401)
                     if (securityScheme.scheme?.startsWith("uav:")) {
                         throw new Error(
                             `Unsupported OPC UA security scheme '${securityScheme.scheme}'. ` +

--- a/packages/binding-opcua/src/opcua-security-resolver.ts
+++ b/packages/binding-opcua/src/opcua-security-resolver.ts
@@ -21,7 +21,12 @@ import {
     UserTokenType,
 } from "node-opcua-client";
 import { convertPEMtoDER } from "node-opcua-crypto";
-import { OPCUACAuthenticationScheme, OPCUAChannelSecurityScheme } from "./security-scheme";
+import {
+    OPCUACAuthenticationScheme,
+    OPCUACUserNameAuthenticationScheme,
+    OPCUACertificateAuthenticationScheme,
+    OPCUAChannelSecurityScheme,
+} from "./security-scheme";
 
 export interface OPCUAChannelSecuritySettings {
     securityPolicy: SecurityPolicy;
@@ -42,8 +47,11 @@ export function resolveChannelSecurity(security: OPCUAChannelSecurityScheme): OP
             throw new Error(`Invalid security policy '${security.policy}'`);
         }
 
+        // Anything outside the modes we know is refused rather than quietly
+        // turned into None, which would connect with less security than asked for.
+        const messageMode: string = security.messageMode;
         let messageSecurityMode: MessageSecurityMode = MessageSecurityMode.Invalid;
-        switch (security.messageMode) {
+        switch (messageMode) {
             case "sign":
                 messageSecurityMode = MessageSecurityMode.Sign;
                 break;
@@ -51,8 +59,7 @@ export function resolveChannelSecurity(security: OPCUAChannelSecurityScheme): OP
                 messageSecurityMode = MessageSecurityMode.SignAndEncrypt;
                 break;
             default:
-                messageSecurityMode = MessageSecurityMode.None;
-                break;
+                throw new Error(`Invalid message mode '${messageMode}'`);
         }
 
         return {
@@ -75,29 +82,36 @@ export function resolveChannelSecurity(security: OPCUAChannelSecurityScheme): OP
  */
 export function resolvedUserIdentity(security: OPCUACAuthenticationScheme) {
     let userIdentity: UserIdentityInfo;
-    switch (security.tokenType) {
-        case "username":
+    const tokenType: string = security.tokenType;
+    switch (tokenType) {
+        case "username": {
+            const userScheme = security as OPCUACUserNameAuthenticationScheme;
             userIdentity = <UserIdentityInfoUserName>{
                 type: UserTokenType.UserName,
-                password: security.password,
-                userName: security.userName,
+                password: userScheme.password,
+                userName: userScheme.userName,
             };
             break;
-        case "certificate":
+        }
+        case "certificate": {
+            const certScheme = security as OPCUACertificateAuthenticationScheme;
             userIdentity = <UserIdentityInfoX509>{
                 type: UserTokenType.Certificate,
-                certificateData: convertPEMtoDER(security.certificate),
-                privateKey: security.privateKey,
+                certificateData: convertPEMtoDER(certScheme.certificate),
+                privateKey: certScheme.privateKey,
             };
             break;
+        }
         case "anonymous":
-        default:
-            // it is OK to use anonymous as default,
-            // as it provides the lowest privileges
             userIdentity = <UserIdentityInfo>{
                 type: UserTokenType.Anonymous,
             };
             break;
+        default:
+            // Anonymous is the right default for an identity that was never
+            // requested. It is the wrong answer for one we failed to recognise:
+            // the author asked for an identity and would get none, silently.
+            throw new Error(`Invalid user identity token type '${tokenType}'`);
     }
 
     return userIdentity;

--- a/packages/binding-opcua/src/opcua-security-resolver.ts
+++ b/packages/binding-opcua/src/opcua-security-resolver.ts
@@ -21,12 +21,7 @@ import {
     UserTokenType,
 } from "node-opcua-client";
 import { convertPEMtoDER } from "node-opcua-crypto";
-import {
-    OPCUACAuthenticationScheme,
-    OPCUACUserNameAuthenticationScheme,
-    OPCUACertificateAuthenticationScheme,
-    OPCUAChannelSecurityScheme,
-} from "./security-scheme";
+import { OPCUACAuthenticationScheme, OPCUAChannelSecurityScheme } from "./security-scheme";
 
 export interface OPCUAChannelSecuritySettings {
     securityPolicy: SecurityPolicy;
@@ -39,28 +34,43 @@ export interface OPCUAChannelSecuritySettings {
  * @param security The OPC UA channel security scheme.
  * @returns The resolved channel security settings.
  */
+/**
+ * Coerces a uav:securityPolicy value into a node-opcua SecurityPolicy.
+ * OPC 10101 uses the short names ("Basic256Sha256"); the full policy URI is accepted
+ * as an extension, since it is what OPC UA itself puts on the wire.
+ */
+function coerceSecurityPolicy(policy: string): SecurityPolicy {
+    const byName = SecurityPolicy[policy as keyof typeof SecurityPolicy];
+    if (byName !== undefined) {
+        return byName;
+    }
+    const byUri = Object.values(SecurityPolicy).find((uri) => uri === policy);
+    if (byUri !== undefined) {
+        return byUri as SecurityPolicy;
+    }
+    throw new Error(`Invalid security policy '${policy}'`);
+}
+
 export function resolveChannelSecurity(security: OPCUAChannelSecurityScheme): OPCUAChannelSecuritySettings {
-    if (security.scheme === "uav:channel-security" && security.messageMode !== "none") {
-        const securityPolicy: SecurityPolicy = SecurityPolicy[security.policy as keyof typeof SecurityPolicy];
+    const mode = security["uav:securityMode"];
 
-        if (securityPolicy === undefined) {
-            throw new Error(`Invalid security policy '${security.policy}'`);
+    // Any value outside the three the specification defines is refused rather than
+    // quietly downgraded, which would connect with less security than was asked for.
+    if (mode !== "None" && mode !== "Sign" && mode !== "SignAndEncrypt") {
+        throw new Error(
+            `Invalid security mode '${mode}': expecting one of "None", "Sign" or "SignAndEncrypt" (OPC 10101 6.3.3)`
+        );
+    }
+
+    if (security.scheme === "uav:channelsec" && mode !== "None") {
+        const policy = security["uav:securityPolicy"];
+        const securityPolicy = coerceSecurityPolicy(policy as string);
+
+        if (securityPolicy === SecurityPolicy.None) {
+            throw new Error(`Security policy 'None' cannot be used with security mode '${mode}'`);
         }
 
-        // Anything outside the modes we know is refused rather than quietly
-        // turned into None, which would connect with less security than asked for.
-        const messageMode: string = security.messageMode;
-        let messageSecurityMode: MessageSecurityMode = MessageSecurityMode.Invalid;
-        switch (messageMode) {
-            case "sign":
-                messageSecurityMode = MessageSecurityMode.Sign;
-                break;
-            case "sign_encrypt":
-                messageSecurityMode = MessageSecurityMode.SignAndEncrypt;
-                break;
-            default:
-                throw new Error(`Invalid message mode '${messageMode}'`);
-        }
+        const messageSecurityMode = mode === "Sign" ? MessageSecurityMode.Sign : MessageSecurityMode.SignAndEncrypt;
 
         return {
             securityPolicy,
@@ -82,36 +92,37 @@ export function resolveChannelSecurity(security: OPCUAChannelSecurityScheme): OP
  */
 export function resolvedUserIdentity(security: OPCUACAuthenticationScheme) {
     let userIdentity: UserIdentityInfo;
-    const tokenType: string = security.tokenType;
+    const tokenType = security["uav:userIdentityToken"];
     switch (tokenType) {
-        case "username": {
-            const userScheme = security as OPCUACUserNameAuthenticationScheme;
+        case "UserName":
             userIdentity = <UserIdentityInfoUserName>{
                 type: UserTokenType.UserName,
-                password: userScheme.password,
-                userName: userScheme.userName,
+                password: security.password,
+                userName: security.userName,
             };
             break;
-        }
-        case "certificate": {
-            const certScheme = security as OPCUACertificateAuthenticationScheme;
+        case "Certificate":
             userIdentity = <UserIdentityInfoX509>{
                 type: UserTokenType.Certificate,
-                certificateData: convertPEMtoDER(certScheme.certificate),
-                privateKey: certScheme.privateKey,
+                certificateData: convertPEMtoDER(security.certificate),
+                privateKey: security.privateKey,
             };
             break;
-        }
-        case "anonymous":
+        case "Anonymous":
             userIdentity = <UserIdentityInfo>{
                 type: UserTokenType.Anonymous,
             };
             break;
+        case "IssuedToken":
+            // Defined by OPC 10101 6.3.3, but node-opcua has no support for issued
+            // tokens. Refusing is the only safe answer: falling back to Anonymous
+            // would connect with fewer privileges than the author asked for, silently.
+            throw new Error("User identity token 'IssuedToken' (uav:issueToken) is not supported yet by this binding");
         default:
-            // Anonymous is the right default for an identity that was never
-            // requested. It is the wrong answer for one we failed to recognise:
-            // the author asked for an identity and would get none, silently.
-            throw new Error(`Invalid user identity token type '${tokenType}'`);
+            throw new Error(
+                `Invalid user identity token '${tokenType}': expecting one of "Anonymous", ` +
+                    `"UserName", "Certificate" or "IssuedToken" (OPC 10101 6.3.3)`
+            );
     }
 
     return userIdentity;

--- a/packages/binding-opcua/src/opcua-security-resolver.ts
+++ b/packages/binding-opcua/src/opcua-security-resolver.ts
@@ -21,7 +21,15 @@ import {
     UserTokenType,
 } from "node-opcua-client";
 import { convertPEMtoDER } from "node-opcua-crypto";
-import { OPCUACAuthenticationScheme, OPCUAChannelSecurityScheme } from "./security-scheme";
+import {
+    OPCUACertificateCredentials,
+    OPCUAUserNameCredentials,
+    OPCUACAuthenticationScheme,
+    OPCUAChannelSecurityScheme,
+    OPCUACredentials,
+    isCertificateCredentials,
+    isUserNameCredentials,
+} from "./security-scheme";
 
 export interface OPCUAChannelSecuritySettings {
     securityPolicy: SecurityPolicy;
@@ -85,29 +93,68 @@ export function resolveChannelSecurity(security: OPCUAChannelSecurityScheme): OP
 }
 
 /**
+ * Picks the credentials matching what the authentication scheme asks for.
+ *
+ * The servient hands credentials over in two different shapes depending on where the
+ * security is declared: form-level security goes through `retrieveCredentials()` and
+ * yields an array, thing-level security through the deprecated `getCredentials()` and
+ * yields a single object. Both are accepted here.
+ */
+function selectCredentials(
+    credentials: unknown,
+    matches: (candidate: OPCUACredentials) => boolean
+): OPCUACredentials | undefined {
+    const candidates = (Array.isArray(credentials) ? credentials : [credentials]) as OPCUACredentials[];
+    return candidates.find((candidate) => candidate != null && matches(candidate));
+}
+
+/**
  * Resolves the user identity information from the given authentication scheme.
- * Will throw an error if the token type is invalid.
+ *
+ * The scheme says which kind of identity to use; the identity itself comes from the
+ * servient credential store, as OPC 10101 §6.3.3 requires. Will throw if the token
+ * type is invalid or if the credentials it needs are missing.
+ *
  * @param security The OPC UA authentication scheme.
+ * @param credentials The credentials registered for the thing, if any.
  * @returns The resolved user identity information.
  */
-export function resolvedUserIdentity(security: OPCUACAuthenticationScheme) {
+export function resolvedUserIdentity(security: OPCUACAuthenticationScheme, credentials?: unknown) {
     let userIdentity: UserIdentityInfo;
     const tokenType = security["uav:userIdentityToken"];
     switch (tokenType) {
-        case "UserName":
+        case "UserName": {
+            const selected = selectCredentials(credentials, isUserNameCredentials);
+            if (selected === undefined) {
+                throw new Error(
+                    "No user name credentials for this thing: a 'UserName' authentication scheme requires " +
+                        "{ userName, password } to be registered with servient.addCredentials(), keyed by the thing id"
+                );
+            }
+            const { userName, password } = selected as OPCUAUserNameCredentials;
             userIdentity = <UserIdentityInfoUserName>{
                 type: UserTokenType.UserName,
-                password: security.password,
-                userName: security.userName,
+                password,
+                userName,
             };
             break;
-        case "Certificate":
+        }
+        case "Certificate": {
+            const selected = selectCredentials(credentials, isCertificateCredentials);
+            if (selected === undefined) {
+                throw new Error(
+                    "No certificate credentials for this thing: a 'Certificate' authentication scheme requires " +
+                        "{ certificate, privateKey } to be registered with servient.addCredentials(), keyed by the thing id"
+                );
+            }
+            const { certificate, privateKey } = selected as OPCUACertificateCredentials;
             userIdentity = <UserIdentityInfoX509>{
                 type: UserTokenType.Certificate,
-                certificateData: convertPEMtoDER(security.certificate),
-                privateKey: security.privateKey,
+                certificateData: convertPEMtoDER(certificate),
+                privateKey,
             };
             break;
+        }
         case "Anonymous":
             userIdentity = <UserIdentityInfo>{
                 type: UserTokenType.Anonymous,

--- a/packages/binding-opcua/src/security-scheme.ts
+++ b/packages/binding-opcua/src/security-scheme.ts
@@ -43,15 +43,6 @@ export type ValidOPCUASecurityPolicy =
 // deprecated |  "Basic256" | "http://opcfoundation.org/UA/SecurityPolicy#Basic256"
 
 /**
- * Names used before OPC 10101 v1.00 was published. They are no longer accepted;
- * they are kept here only so that the binding can raise a migration error that
- * names the replacement. See #1401.
- */
-export const DEPRECATED_SCHEME_NAMES: Readonly<Record<string, string>> = {
-    "uav:channel-security": "uav:channelsec",
-};
-
-/**
  * A channel security scheme, as defined in OPC 10101 "OPC UA for WoT Binding" §6.3.3.
  */
 export interface OPCUASecureSecurityScheme extends OPCUASecuritySchemeBase {

--- a/packages/binding-opcua/src/security-scheme.ts
+++ b/packages/binding-opcua/src/security-scheme.ts
@@ -17,7 +17,7 @@
 import * as TDT from "wot-thing-description-types";
 import { SecurityScheme } from "@node-wot/core";
 export interface OPCUASecuritySchemeBase extends SecurityScheme, TDT.AdditionalSecurityScheme {
-    scheme: "uav:channel-security" | "uav:authentication";
+    scheme: "uav:channelsec" | "uav:authentication";
 }
 
 export type ValidOPCUASecurityPolicy =
@@ -43,34 +43,52 @@ export type ValidOPCUASecurityPolicy =
 // deprecated |  "Basic256" | "http://opcfoundation.org/UA/SecurityPolicy#Basic256"
 
 /**
- *
+ * Names used before OPC 10101 v1.00 was published. They are no longer accepted;
+ * they are kept here only so that the binding can raise a migration error that
+ * names the replacement. See #1401.
+ */
+export const DEPRECATED_SCHEME_NAMES: Readonly<Record<string, string>> = {
+    "uav:channel-security": "uav:channelsec",
+};
+
+/**
+ * A channel security scheme, as defined in OPC 10101 "OPC UA for WoT Binding" §6.3.3.
  */
 export interface OPCUASecureSecurityScheme extends OPCUASecuritySchemeBase {
-    scheme: "uav:channel-security";
-    policy: ValidOPCUASecurityPolicy;
-    messageMode: "sign" | "sign_encrypt";
+    scheme: "uav:channelsec";
+    "uav:securityPolicy": ValidOPCUASecurityPolicy;
+    "uav:securityMode": "Sign" | "SignAndEncrypt";
 }
 export interface OPCUAUnsecureChannelScheme extends OPCUASecuritySchemeBase {
-    scheme: "uav:channel-security";
-    policy: never;
-    messageMode: "none";
+    scheme: "uav:channelsec";
+    // OPC 10101 lists uav:securityPolicy as required and allows the value "None",
+    // so it is accepted here, but it carries no information when the mode is "None".
+    "uav:securityPolicy"?: "None";
+    "uav:securityMode": "None";
 }
 
 export type OPCUAChannelSecurityScheme = OPCUASecureSecurityScheme | OPCUAUnsecureChannelScheme;
+
+/**
+ * An authentication scheme, as defined in OPC 10101 "OPC UA for WoT Binding" §6.5.
+ *
+ * Note: "IssuedToken" (uav:issueToken) is not implemented, as node-opcua does not
+ * support issued tokens yet.
+ */
 export interface OPCUACAuthenticationSchemeBase extends OPCUASecuritySchemeBase {
     scheme: "uav:authentication";
-    tokenType: "username" | "certificate" | "anonymous";
+    "uav:userIdentityToken": "UserName" | "Certificate" | "Anonymous" | "IssuedToken";
 }
 
 export interface OPCUACUserNameAuthenticationScheme extends OPCUACAuthenticationSchemeBase {
     scheme: "uav:authentication";
-    tokenType: "username";
+    "uav:userIdentityToken": "UserName";
     userName: string;
     password?: string;
 }
 export interface OPCUACertificateAuthenticationScheme extends OPCUACAuthenticationSchemeBase {
     scheme: "uav:authentication";
-    tokenType: "certificate";
+    "uav:userIdentityToken": "Certificate";
     // the certificate in PEM format
     //  -----BEGIN CERTIFICATE----
     //  ...
@@ -85,9 +103,21 @@ export interface OPCUACertificateAuthenticationScheme extends OPCUACAuthenticati
 }
 export interface OPCUAAnonymousAuthenticationScheme extends OPCUACAuthenticationSchemeBase {
     scheme: "uav:authentication";
-    tokenType: "anonymous";
+    "uav:userIdentityToken": "Anonymous";
+}
+/**
+ * Declared for completeness with OPC 10101 6.3.3. Recognised but not usable:
+ * node-opcua has no support for issued tokens, so resolving one raises an error
+ * rather than falling back to a weaker identity.
+ */
+export interface OPCUAIssuedTokenAuthenticationScheme extends OPCUACAuthenticationSchemeBase {
+    scheme: "uav:authentication";
+    "uav:userIdentityToken": "IssuedToken";
+    // name of another security scheme in the same thing description, e.g. an oauth2 one
+    "uav:issueToken"?: string;
 }
 export type OPCUACAuthenticationScheme =
     | OPCUAAnonymousAuthenticationScheme
+    | OPCUAIssuedTokenAuthenticationScheme
     | OPCUACertificateAuthenticationScheme
     | OPCUACUserNameAuthenticationScheme;

--- a/packages/binding-opcua/src/security-scheme.ts
+++ b/packages/binding-opcua/src/security-scheme.ts
@@ -70,7 +70,11 @@ export interface OPCUAUnsecureChannelScheme extends OPCUASecuritySchemeBase {
 export type OPCUAChannelSecurityScheme = OPCUASecureSecurityScheme | OPCUAUnsecureChannelScheme;
 
 /**
- * An authentication scheme, as defined in OPC 10101 "OPC UA for WoT Binding" §6.5.
+ * An authentication scheme, as defined in OPC 10101 "OPC UA for WoT Binding" §6.3.3.
+ *
+ * The scheme states *which kind* of identity to use. It never carries the identity
+ * itself: §6.3.2 and §6.3.3 both require that credentials be supplied out of band.
+ * See {@link OPCUACredentials}.
  *
  * Note: "IssuedToken" (uav:issueToken) is not implemented, as node-opcua does not
  * support issued tokens yet.
@@ -83,23 +87,10 @@ export interface OPCUACAuthenticationSchemeBase extends OPCUASecuritySchemeBase 
 export interface OPCUACUserNameAuthenticationScheme extends OPCUACAuthenticationSchemeBase {
     scheme: "uav:authentication";
     "uav:userIdentityToken": "UserName";
-    userName: string;
-    password?: string;
 }
 export interface OPCUACertificateAuthenticationScheme extends OPCUACAuthenticationSchemeBase {
     scheme: "uav:authentication";
     "uav:userIdentityToken": "Certificate";
-    // the certificate in PEM format
-    //  -----BEGIN CERTIFICATE----
-    //  ...
-    //  -----END CERTIFICATE-----
-    certificate: string;
-    // the private key in PEM format that is associated with the certificate
-    // For instance
-    //  -----BEGIN PRIVATE KEY-----
-    //  ...
-    //  -----END PRIVATE KEY-----
-    privateKey?: string;
 }
 export interface OPCUAAnonymousAuthenticationScheme extends OPCUACAuthenticationSchemeBase {
     scheme: "uav:authentication";
@@ -121,3 +112,50 @@ export type OPCUACAuthenticationScheme =
     | OPCUAIssuedTokenAuthenticationScheme
     | OPCUACertificateAuthenticationScheme
     | OPCUACUserNameAuthenticationScheme;
+
+/**
+ * Credentials for a "UserName" authentication scheme.
+ */
+export interface OPCUAUserNameCredentials {
+    userName: string;
+    password?: string;
+}
+
+/**
+ * Credentials for a "Certificate" authentication scheme.
+ */
+export interface OPCUACertificateCredentials {
+    // the certificate in PEM format
+    //  -----BEGIN CERTIFICATE----
+    //  ...
+    //  -----END CERTIFICATE-----
+    certificate: string;
+    // the private key in PEM format that is associated with the certificate
+    // For instance
+    //  -----BEGIN PRIVATE KEY-----
+    //  ...
+    //  -----END PRIVATE KEY-----
+    privateKey?: string;
+}
+
+/**
+ * Credentials for an OPC UA thing.
+ *
+ * OPC 10101 §6.3.2 and §6.3.3 state that "login credentials such as user name and
+ * passwords or certificates are not shared in WoT Thing Descriptions and must be
+ * provided separately". They are therefore supplied through the servient, keyed by
+ * the thing id:
+ *
+ * ```js
+ * servient.addCredentials({ "urn:my-thing": { userName: "joe", password: "secret" } });
+ * ```
+ */
+export type OPCUACredentials = OPCUAUserNameCredentials | OPCUACertificateCredentials;
+
+export function isUserNameCredentials(credentials: OPCUACredentials): credentials is OPCUAUserNameCredentials {
+    return (credentials as OPCUAUserNameCredentials).userName !== undefined;
+}
+
+export function isCertificateCredentials(credentials: OPCUACredentials): credentials is OPCUACertificateCredentials {
+    return (credentials as OPCUACertificateCredentials).certificate !== undefined;
+}

--- a/packages/binding-opcua/test/opcua-security-e2e-test.ts
+++ b/packages/binding-opcua/test/opcua-security-e2e-test.ts
@@ -1,0 +1,319 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+
+//
+// End-to-end tour of OPC UA security in node-wot, against a real OPC UA server.
+//
+// It is meant to be read top to bottom: each test builds one Thing Description,
+// connects with it, and then asks the server "who am I, and how did I connect?"
+// through the WhoAmI method. That answer comes from the *server*, so it reports
+// what actually happened on the wire, not what the Thing Description asked for.
+// That distinction is the point: a security bug in a binding looks exactly like
+// a working connection until you ask the other side what it saw.
+//
+// Reference: OPC 10101 "OPC UA for WoT Binding" v1.00, section 6.3.
+// opcua-security-test.ts covers the same ground exhaustively and table-driven;
+// this file is the narrative version.
+//
+import { expect } from "chai";
+import { Servient } from "@node-wot/core";
+import { OPCUAClient, OPCUAServer, SecurityPolicy } from "node-opcua";
+
+import { OPCUAClientFactory, OPCUACredentials } from "../src";
+import { startServer } from "./fixture/basic-opcua-server";
+import { CertificateManagerSingleton } from "../src/certificate-manager-singleton";
+
+// What the server reports back about the session it granted.
+interface WhoAmI {
+    UserName: string | null;
+    UserIdentityTokenType: string | null;
+    ChannelSecurityMode: string | null;
+    ChannelSecurityPolicyUri: string | null;
+}
+
+// Credentials are stored per Thing, so the Thing Description needs an id.
+const thingId = "urn:node-wot:opcua-security-e2e";
+
+describe("OPCUA security, end to end", function () {
+    let opcuaServer: OPCUAServer;
+    let endpoint: string;
+
+    before(async () => {
+        opcuaServer = await startServer();
+        endpoint = opcuaServer.getEndpointUrl();
+
+        // Each side must trust the other's certificate before an encrypted
+        // channel can be opened. A real deployment arranges this out of band;
+        // here the fixture does it.
+        const clientCertificateManager = await CertificateManagerSingleton.getCertificateManager();
+        await clientCertificateManager.trustCertificate(opcuaServer.getCertificate());
+
+        const client = OPCUAClient.create({ clientCertificateManager });
+        await client.createDefaultCertificate();
+        await opcuaServer.serverCertificateManager.trustCertificate(client.getCertificateChain());
+    });
+
+    after(async () => {
+        await opcuaServer.shutdown();
+    });
+
+    /**
+     * Wraps the given security definitions in a Thing Description, so that each
+     * test below shows only the part that is its actual subject.
+     */
+    function makeThingDescription(
+        securityDefinitions: Record<string, unknown>,
+        security: string
+    ): WoT.ThingDescription {
+        return {
+            "@context": ["https://www.w3.org/2022/wot/td/v1.1", { uav: "http://opcfoundation.org/UA/WoT-Binding/" }],
+            "@type": ["Thing"],
+            id: thingId,
+            title: "sensor",
+            base: endpoint,
+            securityDefinitions,
+            security,
+            properties: {
+                temperature: {
+                    type: "number",
+                    readOnly: true,
+                    forms: [
+                        {
+                            href: "/",
+                            op: ["readproperty"],
+                            "opcua:nodeId": {
+                                root: "i=84",
+                                path: "/Objects/1:MySensor/2:ParameterSet/1:Temperature",
+                            },
+                            contentType: "application/json",
+                        },
+                    ],
+                },
+            },
+            actions: {
+                // The server answers this one with a description of the session
+                // it actually granted, which is what every test below asserts on.
+                whoAmI: {
+                    forms: [
+                        {
+                            type: "object",
+                            href: "/",
+                            op: ["invokeaction"],
+                            "opcua:nodeId": { root: "i=84", path: "/Objects/Server" },
+                            "opcua:method": { root: "i=84", path: "/Objects/Server/1:WhoAmI" },
+                        },
+                    ],
+                    input: { type: "object", properties: {}, required: [] },
+                    output: {
+                        type: "object",
+                        properties: {
+                            UserName: { type: "string" },
+                            UserIdentityTokenType: { type: "string" },
+                            ChannelSecurityMode: { type: "string" },
+                            ChannelSecurityPolicyUri: { type: "string" },
+                        },
+                        required: [
+                            "UserName",
+                            "UserIdentityTokenType",
+                            "ChannelSecurityMode",
+                            "ChannelSecurityPolicyUri",
+                        ],
+                    },
+                },
+            },
+        } as unknown as WoT.ThingDescription;
+    }
+
+    /**
+     * Consumes the Thing, reads the temperature, then asks the server what kind
+     * of session it granted. Credentials, when supplied, go to the servient and
+     * never into the Thing Description (OPC 10101 6.3.3).
+     */
+    async function connectAndAsk(
+        securityDefinitions: Record<string, unknown>,
+        security: string,
+        credentials?: OPCUACredentials
+    ): Promise<{ temperature: number; whoAmI: WhoAmI }> {
+        const servient = new Servient();
+        servient.addClientFactory(new OPCUAClientFactory());
+        if (credentials !== undefined) {
+            servient.addCredentials({ [thingId]: credentials });
+        }
+        try {
+            const wot = await servient.start();
+            const thing = await wot.consume(makeThingDescription(securityDefinitions, security));
+
+            const temperature = (await (await thing.readProperty("temperature")).value()) as number;
+            const whoAmI = (await (await thing.invokeAction("whoAmI", {}))?.value()) as WhoAmI;
+            return { temperature, whoAmI };
+        } finally {
+            await servient.shutdown();
+        }
+    }
+
+    async function expectRefusal(promise: Promise<unknown>, message: RegExp): Promise<void> {
+        try {
+            await promise;
+        } catch (err) {
+            expect((err as Error).message).to.match(message);
+            return;
+        }
+        expect.fail(`expected the connection to be refused with ${message}`);
+    }
+
+    // ------------------------------------------------------------------
+    // 1. No security at all - OPC 10101 6.3.1
+    // ------------------------------------------------------------------
+    it("E2E-1 - nosec connects in plain text as an anonymous user", async () => {
+        const { temperature, whoAmI } = await connectAndAsk({ nosec_sc: { scheme: "nosec" } }, "nosec_sc");
+
+        expect(temperature).to.eql(25);
+        expect(whoAmI.ChannelSecurityMode).to.eql("None");
+        expect(whoAmI.UserIdentityTokenType).to.eql("AnonymousIdentityToken");
+    });
+
+    // ------------------------------------------------------------------
+    // 2. Channel security alone - the connection is protected, nobody is named
+    // ------------------------------------------------------------------
+    it("E2E-2 - uav:channelsec encrypts the channel, and the user stays anonymous", async () => {
+        const { whoAmI } = await connectAndAsk(
+            {
+                channel_sc: {
+                    scheme: "uav:channelsec",
+                    "uav:securityMode": "SignAndEncrypt",
+                    "uav:securityPolicy": "Basic256Sha256",
+                },
+            },
+            "channel_sc"
+        );
+
+        // The channel is protected...
+        expect(whoAmI.ChannelSecurityMode).to.eql("SignAndEncrypt");
+        expect(whoAmI.ChannelSecurityPolicyUri).to.eql(SecurityPolicy.Basic256Sha256);
+        // ...but nothing was said about *who* connects, so: anonymous.
+        expect(whoAmI.UserIdentityTokenType).to.eql("AnonymousIdentityToken");
+    });
+
+    // ------------------------------------------------------------------
+    // 3. Authentication alone - the user is named, the wire is readable
+    // ------------------------------------------------------------------
+    it("E2E-3 - uav:authentication names the user, over an unprotected channel", async () => {
+        const { whoAmI } = await connectAndAsk(
+            { user_sc: { scheme: "uav:authentication", "uav:userIdentityToken": "UserName" } },
+            "user_sc",
+            // Note where the password lives: in the servient, not in the TD.
+            { userName: "joe", password: "password_for_joe" }
+        );
+
+        expect(whoAmI.UserName).to.eql("joe");
+        expect(whoAmI.UserIdentityTokenType).to.eql("UserNameIdentityToken");
+        // The two layers really are independent: naming a user secures nothing
+        // about the connection carrying that name.
+        expect(whoAmI.ChannelSecurityMode).to.eql("None");
+    });
+
+    // ------------------------------------------------------------------
+    // 4. Both layers - what a production Thing Description looks like
+    // ------------------------------------------------------------------
+    it("E2E-4 - combo/allOf applies both layers at once", async () => {
+        const { whoAmI } = await connectAndAsk(
+            {
+                channel_sc: {
+                    scheme: "uav:channelsec",
+                    "uav:securityMode": "SignAndEncrypt",
+                    "uav:securityPolicy": "Basic256Sha256",
+                },
+                user_sc: { scheme: "uav:authentication", "uav:userIdentityToken": "UserName" },
+                secure_sc: { scheme: "combo", allOf: ["channel_sc", "user_sc"] },
+            },
+            "secure_sc",
+            { userName: "joe", password: "password_for_joe" }
+        );
+
+        expect(whoAmI.ChannelSecurityMode).to.eql("SignAndEncrypt");
+        expect(whoAmI.UserName).to.eql("joe");
+        expect(whoAmI.UserIdentityTokenType).to.eql("UserNameIdentityToken");
+    });
+
+    // ------------------------------------------------------------------
+    // 5. Letting the client choose - OPC 10101 6.3.2
+    // ------------------------------------------------------------------
+    it("E2E-5 - auto picks the strongest channel the server advertises", async () => {
+        const { whoAmI } = await connectAndAsk({ auto_sc: { scheme: "auto" } }, "auto_sc");
+
+        // No mode was named; the client asked the server and took the best one.
+        expect(whoAmI.ChannelSecurityMode).to.eql("SignAndEncrypt");
+        expect(whoAmI.ChannelSecurityPolicyUri).to.not.eql(SecurityPolicy.None);
+    });
+
+    // ------------------------------------------------------------------
+    // 6. The failure modes. Every one of these used to connect anyway.
+    //
+    // A binding that ignores what it does not understand connects with its own
+    // defaults - no encryption, no user - and reports success. So each case
+    // here must raise rather than degrade.
+    // ------------------------------------------------------------------
+    it("E2E-6 - refuses a UserName scheme when no credentials were registered", async () => {
+        await expectRefusal(
+            connectAndAsk(
+                { user_sc: { scheme: "uav:authentication", "uav:userIdentityToken": "UserName" } },
+                "user_sc"
+            ),
+            /No user name credentials/
+        );
+    });
+
+    it("E2E-7 - refuses the pre-1.00 scheme name, and says what to write instead", async () => {
+        await expectRefusal(
+            connectAndAsk(
+                {
+                    old_sc: {
+                        scheme: "uav:channel-security", // the spelling used before OPC 10101 v1.00
+                        messageMode: "sign_encrypt",
+                        policy: "Basic256Sha256",
+                    },
+                },
+                "old_sc"
+            ),
+            /uav:channelsec/
+        );
+    });
+
+    it("E2E-8 - refuses IssuedToken, which the spec defines but node-opcua cannot do", async () => {
+        await expectRefusal(
+            connectAndAsk(
+                { issued_sc: { scheme: "uav:authentication", "uav:userIdentityToken": "IssuedToken" } },
+                "issued_sc"
+            ),
+            /IssuedToken/
+        );
+    });
+
+    it("E2E-9 - refuses an unknown security mode rather than downgrading it", async () => {
+        await expectRefusal(
+            connectAndAsk(
+                {
+                    typo_sc: {
+                        scheme: "uav:channelsec",
+                        "uav:securityMode": "SignAndEncrypted", // typo
+                        "uav:securityPolicy": "Basic256Sha256",
+                    },
+                },
+                "typo_sc"
+            ),
+            /Invalid security mode/
+        );
+    });
+});

--- a/packages/binding-opcua/test/opcua-security-test.ts
+++ b/packages/binding-opcua/test/opcua-security-test.ts
@@ -482,7 +482,7 @@ describe("Testing OPCUA Security Combination", () => {
 });
 
 describe("Testing OPCUA Security Scheme Migration (OPC 10101 v1.00)", () => {
-    it("MIG1 - should reject the pre-1.00 'uav:channel-security' scheme with a message naming its replacement", () => {
+    it("MIG1 - should reject the pre-1.00 'uav:channel-security' scheme rather than ignore it", () => {
         const client = new OPCUAProtocolClient();
         expect(() =>
             client.setSecurity([
@@ -492,7 +492,7 @@ describe("Testing OPCUA Security Scheme Migration (OPC 10101 v1.00)", () => {
                     policy: "Basic256Sha256",
                 } as unknown as SecurityScheme,
             ])
-        ).to.throw(/uav:channelsec/);
+        ).to.throw(/Unsupported OPC UA security scheme 'uav:channel-security'/);
     });
 
     it("MIG1b - should still refuse any other unknown scheme in our namespace", () => {

--- a/packages/binding-opcua/test/opcua-security-test.ts
+++ b/packages/binding-opcua/test/opcua-security-test.ts
@@ -54,53 +54,53 @@ const thingDescription: WoT.ThingDescription = {
         },
         // OPCUAChannelSecurityScheme
         "c:sign-encrypt_basic256Sha256": <OPCUAChannelSecurityScheme>{
-            scheme: "uav:channel-security",
-            messageMode: "sign_encrypt",
-            policy: "Basic256Sha256", // deprecated
+            scheme: "uav:channelsec",
+            "uav:securityMode": "SignAndEncrypt",
+            "uav:securityPolicy": "Basic256Sha256", // deprecated
         },
         // Aes128_Sha256_RsaOaep
         "c:sign-encrypt_aes128Sha256RsaOaep": <OPCUAChannelSecurityScheme>{
-            scheme: "uav:channel-security",
-            messageMode: "sign_encrypt",
-            policy: "Aes128_Sha256_RsaOaep",
+            scheme: "uav:channelsec",
+            "uav:securityMode": "SignAndEncrypt",
+            "uav:securityPolicy": "Aes128_Sha256_RsaOaep",
         },
 
         "c:sign_basic256Sha256": <OPCUAChannelSecurityScheme>{
-            scheme: "uav:channel-security",
-            messageMode: "sign",
-            policy: "Basic256Sha256",
+            scheme: "uav:channelsec",
+            "uav:securityMode": "Sign",
+            "uav:securityPolicy": "Basic256Sha256",
         },
         "c:invalid-sign": <OPCUAChannelSecurityScheme>{
-            scheme: "uav:channel-security",
-            messageMode: "sign",
-            policy: "Basic192Rsa15", // Basic192Rsa15 valid policy but unsupported by server
+            scheme: "uav:channelsec",
+            "uav:securityMode": "Sign",
+            "uav:securityPolicy": "Basic192Rsa15", // Basic192Rsa15 valid policy but unsupported by server
         },
         "c:no_security": <OPCUAChannelSecurityScheme>{
-            scheme: "uav:channel-security",
-            messageMode: "none",
+            scheme: "uav:channelsec",
+            "uav:securityMode": "None",
         },
         //
         "a:username-password": <OPCUACUserNameAuthenticationScheme>{
             scheme: "uav:authentication",
-            tokenType: "username",
+            "uav:userIdentityToken": "UserName",
             userName: "joe",
             password: "password_for_joe",
         },
         "a:username-invalid-password": <OPCUACUserNameAuthenticationScheme>{
             scheme: "uav:authentication",
-            tokenType: "username",
+            "uav:userIdentityToken": "UserName",
             userName: "joe",
             password: "**INVALID**password_for_joe",
         },
         "a:x509-certificate": <OPCUACertificateAuthenticationScheme>{
             scheme: "uav:authentication",
-            tokenType: "certificate",
+            "uav:userIdentityToken": "Certificate",
             certificate: "....",
             privateKey: "....",
         },
         "a:x509-certificate-no-private-key": <OPCUACertificateAuthenticationScheme>{
             scheme: "uav:authentication",
-            tokenType: "certificate",
+            "uav:userIdentityToken": "Certificate",
             certificate: "....",
             privateKey: undefined,
         },
@@ -302,18 +302,18 @@ describe("verify test securityDefinitions", () => {
                 for (const subKey of comboDef.allOf) {
                     expect(definitions).to.have.property(subKey);
                 }
-            } else if (def.scheme === "uav:channel-security") {
+            } else if (def.scheme === "uav:channelsec") {
                 const channelDef = def as OPCUAChannelSecurityScheme;
-                expect(channelDef).to.have.property("messageMode");
-                expect(["none", "sign", "sign_encrypt"]).to.include(channelDef.messageMode);
-                // policy is optional
+                expect(channelDef).to.have.property("uav:securityMode");
+                expect(["None", "Sign", "SignAndEncrypt"]).to.include(channelDef["uav:securityMode"]);
+                // uav:securityPolicy is optional
             } else if (def.scheme === "uav:authentication") {
                 const authDef = def as OPCUACertificateAuthenticationScheme | OPCUACUserNameAuthenticationScheme;
-                expect(authDef).to.have.property("tokenType");
-                if (authDef.tokenType === "username") {
+                expect(authDef).to.have.property("uav:userIdentityToken");
+                if (authDef["uav:userIdentityToken"] === "UserName") {
                     expect(authDef).to.have.property("userName");
                     expect(authDef).to.have.property("password");
-                } else if (authDef.tokenType === "certificate") {
+                } else if (authDef["uav:userIdentityToken"] === "Certificate") {
                     expect(authDef).to.have.property("certificate");
                     expect(authDef).to.have.property("privateKey");
                 }
@@ -460,39 +460,90 @@ describe("Testing OPCUA Security Combination", () => {
     });
 });
 
-describe("Testing unsupported OPCUA security schemes", () => {
-    // A scheme we fail to recognise used to fall through `default:` and leave the
-    // client on its defaults - no encryption, no user - while setSecurity()
-    // returned true. Nothing downstream could detect that, so these must throw.
-
-    it("REFUSE1 - should refuse an unknown scheme in our own namespace", () => {
+describe("Testing OPCUA Security Scheme Migration (OPC 10101 v1.00)", () => {
+    it("MIG1 - should reject the pre-1.00 'uav:channel-security' scheme with a message naming its replacement", () => {
         const client = new OPCUAProtocolClient();
-        expect(() => client.setSecurity([{ scheme: "uav:channelsec" } as unknown as SecurityScheme])).to.throw(
+        expect(() =>
+            client.setSecurity([
+                {
+                    scheme: "uav:channel-security",
+                    messageMode: "sign_encrypt",
+                    policy: "Basic256Sha256",
+                } as unknown as SecurityScheme,
+            ])
+        ).to.throw(/uav:channelsec/);
+    });
+
+    it("MIG1b - should still refuse any other unknown scheme in our namespace", () => {
+        const client = new OPCUAProtocolClient();
+        expect(() => client.setSecurity([{ scheme: "uav:whatever" } as unknown as SecurityScheme])).to.throw(
             /Unsupported OPC UA security scheme/
         );
     });
 
-    it("REFUSE2 - should still ignore schemes belonging to another binding", () => {
+    it("MIG2 - should still ignore security schemes that belong to another binding", () => {
         const client = new OPCUAProtocolClient();
         expect(client.setSecurity([{ scheme: "basic" } as SecurityScheme])).to.eql(true);
     });
+});
 
-    it("REFUSE3 - should refuse an unknown messageMode instead of downgrading it to none", () => {
-        expect(() =>
-            resolveChannelSecurity({
-                scheme: "uav:channel-security",
-                messageMode: "SignAndEncrypt",
-                policy: "Basic256Sha256",
-            } as unknown as OPCUAChannelSecurityScheme)
-        ).to.throw(/Invalid message mode/);
+describe("Testing OPCUA Security Scheme conformance (OPC 10101 6.3.3)", () => {
+    it("CONF1 - should accept the full policy URI as well as the short name", () => {
+        const resolved = resolveChannelSecurity({
+            scheme: "uav:channelsec",
+            "uav:securityMode": "Sign",
+            "uav:securityPolicy": "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
+        } as unknown as OPCUAChannelSecurityScheme);
+        expect(resolved.securityPolicy).to.eql(SecurityPolicy.Basic256Sha256);
+        expect(resolved.messageSecurityMode).to.eql(MessageSecurityMode.Sign);
     });
 
-    it("REFUSE4 - should refuse an unknown tokenType instead of connecting anonymously", () => {
+    it("CONF2 - should accept securityPolicy 'None' together with securityMode 'None'", () => {
+        const resolved = resolveChannelSecurity({
+            scheme: "uav:channelsec",
+            "uav:securityMode": "None",
+            "uav:securityPolicy": "None",
+        } as unknown as OPCUAChannelSecurityScheme);
+        expect(resolved.securityPolicy).to.eql(SecurityPolicy.None);
+        expect(resolved.messageSecurityMode).to.eql(MessageSecurityMode.None);
+    });
+
+    it("CONF3 - should refuse an unknown securityMode instead of downgrading to None", () => {
+        expect(() =>
+            resolveChannelSecurity({
+                scheme: "uav:channelsec",
+                "uav:securityMode": "sign_encrypt",
+                "uav:securityPolicy": "Basic256Sha256",
+            } as unknown as OPCUAChannelSecurityScheme)
+        ).to.throw(/Invalid security mode/);
+    });
+
+    it("CONF4 - should refuse securityPolicy 'None' when the mode asks for security", () => {
+        expect(() =>
+            resolveChannelSecurity({
+                scheme: "uav:channelsec",
+                "uav:securityMode": "SignAndEncrypt",
+                "uav:securityPolicy": "None",
+            } as unknown as OPCUAChannelSecurityScheme)
+        ).to.throw(/cannot be used with security mode/);
+    });
+
+    it("CONF5 - should refuse IssuedToken rather than connect anonymously", () => {
         expect(() =>
             resolvedUserIdentity({
                 scheme: "uav:authentication",
-                tokenType: "IssuedToken",
+                "uav:userIdentityToken": "IssuedToken",
+                "uav:issueToken": "oauth2_sc",
             } as unknown as OPCUACAuthenticationScheme)
-        ).to.throw(/Invalid user identity token type/);
+        ).to.throw(/IssuedToken/);
+    });
+
+    it("CONF6 - should refuse an unknown userIdentityToken rather than connect anonymously", () => {
+        expect(() =>
+            resolvedUserIdentity({
+                scheme: "uav:authentication",
+                "uav:userIdentityToken": "username",
+            } as unknown as OPCUACAuthenticationScheme)
+        ).to.throw(/Invalid user identity token/);
     });
 });

--- a/packages/binding-opcua/test/opcua-security-test.ts
+++ b/packages/binding-opcua/test/opcua-security-test.ts
@@ -20,7 +20,8 @@ import path from "path";
 import { SecurityScheme, Servient, createLoggers } from "@node-wot/core";
 import { InteractionOptions } from "wot-typescript-definitions";
 
-import { MessageSecurityMode, OPCUAClient, OPCUAServer, SecurityPolicy } from "node-opcua";
+import { MessageSecurityMode, OPCUAClient, OPCUAServer, SecurityPolicy, UserTokenType } from "node-opcua";
+import { UserIdentityInfoUserName } from "node-opcua-client";
 import { coercePrivateKeyPem, readCertificate, readCertificatePEM, readPrivateKey } from "node-opcua-crypto";
 import {
     OPCUAClientFactory,
@@ -29,12 +30,15 @@ import {
     OPCUAChannelSecurityScheme,
     OPCUAProtocolClient,
     OPCUACAuthenticationScheme,
+    OPCUACredentials,
 } from "../src";
 import { resolveChannelSecurity, resolvedUserIdentity } from "../src/opcua-security-resolver";
 
 import { startServer } from "./fixture/basic-opcua-server";
 import { CertificateManagerSingleton } from "../src/certificate-manager-singleton";
 const endpoint = "opc.tcp://localhost:7890";
+// credentials are registered against the thing id (see credentialsFor / makeThing)
+const thingId = "urn:node-wot:opcua-security-test";
 
 const { debug } = createLoggers("binding-opcua", "full-opcua-thing-test");
 
@@ -47,6 +51,8 @@ interface WhoAmI {
 const thingDescription: WoT.ThingDescription = {
     "@context": "https://www.w3.org/2019/wot/td/v1",
     "@type": ["Thing"],
+    // credentials are registered against the thing id
+    id: thingId,
 
     securityDefinitions: {
         nosec_sc: {
@@ -80,29 +86,24 @@ const thingDescription: WoT.ThingDescription = {
             "uav:securityMode": "None",
         },
         //
+        // Note: the schemes below carry no credentials. OPC 10101 6.3.3 requires those to be
+        // supplied out of band; the test harness registers them with servient.addCredentials()
+        // and derives which ones from the definition name (see credentialsFor).
         "a:username-password": <OPCUACUserNameAuthenticationScheme>{
             scheme: "uav:authentication",
             "uav:userIdentityToken": "UserName",
-            userName: "joe",
-            password: "password_for_joe",
         },
         "a:username-invalid-password": <OPCUACUserNameAuthenticationScheme>{
             scheme: "uav:authentication",
             "uav:userIdentityToken": "UserName",
-            userName: "joe",
-            password: "**INVALID**password_for_joe",
         },
         "a:x509-certificate": <OPCUACertificateAuthenticationScheme>{
             scheme: "uav:authentication",
             "uav:userIdentityToken": "Certificate",
-            certificate: "....",
-            privateKey: "....",
         },
         "a:x509-certificate-no-private-key": <OPCUACertificateAuthenticationScheme>{
             scheme: "uav:authentication",
             "uav:userIdentityToken": "Certificate",
-            certificate: "....",
-            privateKey: undefined,
         },
         // compbo
         "c:sign_basic256Sha256-a:username-password": {
@@ -310,13 +311,11 @@ describe("verify test securityDefinitions", () => {
             } else if (def.scheme === "uav:authentication") {
                 const authDef = def as OPCUACertificateAuthenticationScheme | OPCUACUserNameAuthenticationScheme;
                 expect(authDef).to.have.property("uav:userIdentityToken");
-                if (authDef["uav:userIdentityToken"] === "UserName") {
-                    expect(authDef).to.have.property("userName");
-                    expect(authDef).to.have.property("password");
-                } else if (authDef["uav:userIdentityToken"] === "Certificate") {
-                    expect(authDef).to.have.property("certificate");
-                    expect(authDef).to.have.property("privateKey");
-                }
+                // credentials must NOT appear in the thing description (OPC 10101 6.3.3)
+                expect(authDef).to.not.have.property("userName");
+                expect(authDef).to.not.have.property("password");
+                expect(authDef).to.not.have.property("certificate");
+                expect(authDef).to.not.have.property("privateKey");
             }
         }
     });
@@ -325,6 +324,29 @@ describe("verify test securityDefinitions", () => {
 describe("Testing OPCUA Security Combination", () => {
     let opcuaServer: OPCUAServer;
     let endpoint: string;
+    // filled in by before(), once the self-signed material has been generated
+    let certificatePem: string;
+    let privateKeyPem: string;
+
+    /**
+     * Credentials are no longer part of the thing description, so the harness derives
+     * them from the security definition name, the same way inferExpectedSecurityMode does.
+     */
+    function credentialsFor(security: string): OPCUACredentials | undefined {
+        if (security.match(/username-invalid-password/)) {
+            return { userName: "joe", password: "**INVALID**password_for_joe" };
+        }
+        if (security.match(/username-password/)) {
+            return { userName: "joe", password: "password_for_joe" };
+        }
+        if (security.match(/no-private-key/)) {
+            return { certificate: certificatePem, privateKey: undefined };
+        }
+        if (security.match(/certificate/)) {
+            return { certificate: certificatePem, privateKey: privateKeyPem };
+        }
+        return undefined;
+    }
     before(async () => {
         opcuaServer = await startServer();
         endpoint = opcuaServer.getEndpointUrl();
@@ -371,14 +393,8 @@ describe("Testing OPCUA Security Combination", () => {
         // adjust thingDescription x509 parameters with generated certficate info
         const joedoeX509CertificatePem = readCertificatePEM(joedoeX509CertificateFilename);
 
-        const x509 = thingDescription.securityDefinitions["a:x509-certificate"];
-        x509.certificate = joedoeX509CertificatePem;
-        const privateKeyPem = coercePrivateKeyPem(readPrivateKey(clientCertificateManager.privateKey));
-        x509.privateKey = privateKeyPem;
-
-        const x509NoPrivateKey = thingDescription.securityDefinitions["a:x509-certificate-no-private-key"];
-        x509NoPrivateKey.certificate = joedoeX509CertificatePem;
-        x509NoPrivateKey.privateKey = undefined;
+        certificatePem = joedoeX509CertificatePem;
+        privateKeyPem = coercePrivateKeyPem(readPrivateKey(clientCertificateManager.privateKey));
     });
     after(async () => {
         await opcuaServer.shutdown();
@@ -397,6 +413,11 @@ describe("Testing OPCUA Security Combination", () => {
         const opcuaClientFactory = new OPCUAClientFactory();
 
         servient.addClientFactory(opcuaClientFactory);
+
+        const credentials = credentialsFor(security);
+        if (credentials !== undefined) {
+            servient.addCredentials({ [thingId]: credentials });
+        }
 
         const wot = await servient.start();
 
@@ -545,5 +566,51 @@ describe("Testing OPCUA Security Scheme conformance (OPC 10101 6.3.3)", () => {
                 "uav:userIdentityToken": "username",
             } as unknown as OPCUACAuthenticationScheme)
         ).to.throw(/Invalid user identity token/);
+    });
+});
+
+describe("Testing OPCUA credentials (OPC 10101 6.3.3)", () => {
+    const userNameScheme = {
+        scheme: "uav:authentication",
+        "uav:userIdentityToken": "UserName",
+    } as unknown as OPCUACAuthenticationScheme;
+
+    it("CRED1 - should refuse a UserName scheme when no credentials are registered", () => {
+        expect(() => resolvedUserIdentity(userNameScheme)).to.throw(/No user name credentials/);
+    });
+
+    it("CRED2 - should refuse a Certificate scheme when no credentials are registered", () => {
+        expect(() =>
+            resolvedUserIdentity({
+                scheme: "uav:authentication",
+                "uav:userIdentityToken": "Certificate",
+            } as unknown as OPCUACAuthenticationScheme)
+        ).to.throw(/No certificate credentials/);
+    });
+
+    it("CRED3 - should accept credentials given as a single object (thing-level security)", () => {
+        const identity = resolvedUserIdentity(userNameScheme, { userName: "joe", password: "secret" });
+        expect(identity.type).to.eql(UserTokenType.UserName);
+        expect((identity as UserIdentityInfoUserName).userName).to.eql("joe");
+    });
+
+    it("CRED4 - should accept credentials given as an array (form-level security)", () => {
+        const identity = resolvedUserIdentity(userNameScheme, [{ userName: "joe", password: "secret" }]);
+        expect(identity.type).to.eql(UserTokenType.UserName);
+        expect((identity as UserIdentityInfoUserName).userName).to.eql("joe");
+    });
+
+    it("CRED5 - should pick the entry matching the scheme when several are registered", () => {
+        const identity = resolvedUserIdentity(userNameScheme, [
+            { certificate: "-----BEGIN CERTIFICATE-----" },
+            { userName: "joe", password: "secret" },
+        ]);
+        expect((identity as UserIdentityInfoUserName).userName).to.eql("joe");
+    });
+
+    it("CRED6 - should ignore credentials that do not match the scheme, and refuse", () => {
+        expect(() => resolvedUserIdentity(userNameScheme, [{ certificate: "..." }])).to.throw(
+            /No user name credentials/
+        );
     });
 });

--- a/packages/binding-opcua/test/opcua-security-test.ts
+++ b/packages/binding-opcua/test/opcua-security-test.ts
@@ -17,7 +17,7 @@
 
 import { expect } from "chai";
 import path from "path";
-import { Servient, createLoggers } from "@node-wot/core";
+import { SecurityScheme, Servient, createLoggers } from "@node-wot/core";
 import { InteractionOptions } from "wot-typescript-definitions";
 
 import { MessageSecurityMode, OPCUAClient, OPCUAServer, SecurityPolicy } from "node-opcua";
@@ -27,7 +27,10 @@ import {
     OPCUACUserNameAuthenticationScheme,
     OPCUACertificateAuthenticationScheme,
     OPCUAChannelSecurityScheme,
+    OPCUAProtocolClient,
+    OPCUACAuthenticationScheme,
 } from "../src";
+import { resolveChannelSecurity, resolvedUserIdentity } from "../src/opcua-security-resolver";
 
 import { startServer } from "./fixture/basic-opcua-server";
 import { CertificateManagerSingleton } from "../src/certificate-manager-singleton";
@@ -454,5 +457,42 @@ describe("Testing OPCUA Security Combination", () => {
                 await servient.shutdown();
             }
         });
+    });
+});
+
+describe("Testing unsupported OPCUA security schemes", () => {
+    // A scheme we fail to recognise used to fall through `default:` and leave the
+    // client on its defaults - no encryption, no user - while setSecurity()
+    // returned true. Nothing downstream could detect that, so these must throw.
+
+    it("REFUSE1 - should refuse an unknown scheme in our own namespace", () => {
+        const client = new OPCUAProtocolClient();
+        expect(() => client.setSecurity([{ scheme: "uav:channelsec" } as unknown as SecurityScheme])).to.throw(
+            /Unsupported OPC UA security scheme/
+        );
+    });
+
+    it("REFUSE2 - should still ignore schemes belonging to another binding", () => {
+        const client = new OPCUAProtocolClient();
+        expect(client.setSecurity([{ scheme: "basic" } as SecurityScheme])).to.eql(true);
+    });
+
+    it("REFUSE3 - should refuse an unknown messageMode instead of downgrading it to none", () => {
+        expect(() =>
+            resolveChannelSecurity({
+                scheme: "uav:channel-security",
+                messageMode: "SignAndEncrypt",
+                policy: "Basic256Sha256",
+            } as unknown as OPCUAChannelSecurityScheme)
+        ).to.throw(/Invalid message mode/);
+    });
+
+    it("REFUSE4 - should refuse an unknown tokenType instead of connecting anonymously", () => {
+        expect(() =>
+            resolvedUserIdentity({
+                scheme: "uav:authentication",
+                tokenType: "IssuedToken",
+            } as unknown as OPCUACAuthenticationScheme)
+        ).to.throw(/Invalid user identity token type/);
     });
 });

--- a/packages/examples/src/bindings/opcua/demo-opcua-secure.ts
+++ b/packages/examples/src/bindings/opcua/demo-opcua-secure.ts
@@ -1,0 +1,112 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the W3C Software Notice and
+ * Document License (2015-05-13) which is available at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR W3C-20150513
+ ********************************************************************************/
+/* eslint  no-console: "off" */
+/* eslint  n/no-process-exit: "off" */
+
+//
+// Connecting to a secured OPC UA server, as described by OPC 10101 §6.3.3:
+// an encrypted and signed channel, with a named user.
+//
+// Start the demo server first:
+//     ts-node packages/binding-opcua/test/fixture/basic-opcua-server.ts
+//
+import { OPCUAClientFactory } from "@node-wot/binding-opcua";
+import { Servient } from "@node-wot/core";
+
+const endpoint = "opc.tcp://localhost:7890";
+
+// The thing id is what credentials are keyed by, so it must be present.
+const thingId = "urn:node-wot:examples:secure-sensor";
+
+const thingDescription: WoT.ThingDescription = {
+    "@context": ["https://www.w3.org/2022/wot/td/v1.1", { uav: "http://opcfoundation.org/UA/WoT-Binding/" }],
+    "@type": ["Thing"],
+    id: thingId,
+    title: "secure-sensor",
+    base: endpoint,
+
+    securityDefinitions: {
+        // Layer 1 — the connection: signed and encrypted.
+        opcua_channel_sc: {
+            scheme: "uav:channelsec",
+            "uav:securityMode": "SignAndEncrypt",
+            "uav:securityPolicy": "Basic256Sha256",
+        },
+        // Layer 2 — who is connecting. Note that no user name or password
+        // appears here: OPC 10101 requires credentials to be supplied
+        // separately, and this binding reads them from the servient.
+        opcua_authentication_sc: {
+            scheme: "uav:authentication",
+            "uav:userIdentityToken": "UserName",
+        },
+        // The two layers are independent, so they are combined with allOf.
+        opcua_sc: {
+            scheme: "combo",
+            allOf: ["opcua_channel_sc", "opcua_authentication_sc"],
+        },
+    },
+    security: "opcua_sc",
+
+    properties: {
+        temperature: {
+            description: "the temperature in the room",
+            type: "number",
+            unit: "°C",
+            observable: true,
+            readOnly: true,
+            forms: [
+                {
+                    href: "/",
+                    op: ["readproperty", "observeproperty"],
+                    "opcua:nodeId": { root: "i=84", path: "/Objects/1:MySensor/2:ParameterSet/1:Temperature" },
+                    contentType: "application/json",
+                },
+            ],
+        },
+    },
+};
+
+(async () => {
+    const servient = new Servient();
+    servient.addClientFactory(new OPCUAClientFactory());
+
+    // The credentials live here, not in the thing description, keyed by thing id.
+    // In a real application they would come from a vault or an operator prompt.
+    servient.addCredentials({
+        [thingId]: {
+            userName: "joe",
+            password: "password_for_joe",
+        },
+    });
+    // For a "Certificate" scheme you would supply PEM material instead:
+    //   servient.addCredentials({ [thingId]: { certificate: certPem, privateKey: keyPem } });
+
+    const wot = await servient.start();
+    const thing = await wot.consume(thingDescription);
+
+    const temperatureProperty = await thing.readProperty("temperature");
+    const temperature = await temperatureProperty.value();
+
+    console.log("------------------------------");
+    console.log("temperature is :", temperature, "°C");
+    console.log("------------------------------");
+
+    await servient.shutdown();
+})().catch((err) => {
+    // A missing or wrong credential is refused here rather than silently
+    // downgraded to an anonymous, unencrypted session.
+    console.error("failed:", (err as Error).message);
+    process.exit(1);
+});


### PR DESCRIPTION

Fixes the OPC UA security schemes in three steps: stop failing open, adopt the vocabularypublished in [OPC 10101 v1.00](https://reference.opcfoundation.org/specs/OPC-10101) §6.3, and take credentials out of the Thing Description.

Discussion and the decision to take the naming as a clean break rather than an alias: #1401.

## Why

A Thing Description written to the published spec did not connect the way it asked to, and said
nothing about it. `setSecurity()` ignored schemes it did not recognise **and returned `true`**, so
the client fell back to `MessageSecurityMode.None` / `SecurityPolicy.None` / anonymous and reported
success. Nothing downstream — application or test — could detect it.

The same shape appeared twice more inside the resolvers:

```ts
case "anonymous":
default:
    // it is OK to use anonymous as default, as it provides the lowest privileges
    userIdentity = { type: UserTokenType.Anonymous };
```

`IssuedToken` is a value OPC 10101 §6.3.3 defines, so a TD copied out of the spec's own OAuth2
example landed here and connected anonymously. An unexpected `uav:securityMode` was likewise
downgraded to `None`.

Anonymous is the correct default for an identity that was never requested. It is the wrong answer
for one we failed to recognise: the author asked for something and got silence.

## The commits

**1. `refuse security schemes we do not understand`**

A scheme in the `uav:` namespace that we cannot honour is now an error, as are an unknown
`messageMode` and an unknown `tokenType`. Schemes belonging to other bindings are still ignored,
as before — that part of the old behaviour was correct.

Written against the *current* vocabulary, so it is independent of the rename below and can be
cherry-picked on its own.

**2. `align security vocabulary with OPC 10101 v1.00`** — breaking

Adopts the published names. The old ones are removed rather than aliased; because commit 1 made an
unrecognised `uav:` scheme fatal, they raise an error naming their replacement instead of silently
degrading.

Also closes what a line-by-line read of §6.3 turned up:

- `IssuedToken` is recognised and refused explicitly (node-opcua cannot do issued tokens — see
  *Follow-ups*), instead of falling through to `Anonymous`.
- `uav:securityPolicy` is marked **required** in §6.3.3 and admits `None`; our types forbade it
  when the mode was `None`. Now accepted, and `None` is refused when the mode asks for security.
- The full policy URI was accepted by the types but threw at runtime, since the enum's *keys* are
  the short names and its *values* are the URIs. Both forms now resolve.

Adds a security section to the binding README. There was none before, so this is new material
rather than an edit, and it covers the documentation checkbox on #1401.

**3. `take credentials from the credential store`** — breaking

§6.3.2 and §6.3.3 both state that credentials "are not shared in WoT Thing Descriptions and must be
provided separately, e.g., through a separate credential store"; every example in the spec declares
`uav:userIdentityToken` and nothing more.

A Thing Description is published, served over the network and committed to repositories by design,
so it is the one artefact where a password must not be written. The inline form is removed rather
than deprecated, because a deprecated path here is still a working way to leak a password.

The machinery already existed: `Servient.addCredentials()` is there and `setSecurity()` already
received the credentials — the binding never read them. Credentials arrive in two shapes (an array
via `retrieveCredentials()` for form-level security, a single object via `getCredentials()` for
thing-level); both are accepted, and there are tests for each so a future core cleanup cannot break
one silently. A scheme whose credentials are missing is refused, not downgraded.

## Breaking changes

Security vocabulary:

| before (0.9.2) | after (OPC 10101 v1.00) |
|---|---|
| `"scheme": "uav:channel-security"` | `"scheme": "uav:channelsec"` |
| `"messageMode": "none" / "sign" / "sign_encrypt"` | `"uav:securityMode": "None" / "Sign" / "SignAndEncrypt"` |
| `"policy": "..."` | `"uav:securityPolicy": "..."` |
| `"tokenType": "anonymous" / "username" / "certificate"` | `"uav:userIdentityToken": "Anonymous" / "UserName" / "Certificate"` |
| `"scheme": "uav:authentication"` | unchanged |

Credentials move from the Thing Description to the servient:

```js
// before — in the TD
{ "scheme": "uav:authentication", "tokenType": "username",
  "userName": "joe", "password": "secret" }

// after — in the TD
{ "scheme": "uav:authentication", "uav:userIdentityToken": "UserName" }

// after — in the application
servient.addCredentials({ "urn:my-thing": { userName: "joe", password: "secret" } });
```

Credentials are keyed by **thing id**, so a TD that did not declare one now needs it.

Both migrations are mechanical, and every removed spelling produces an error naming its
replacement. A survey of the OPC UA TDs reachable from here — this repo's examples, both TD
generators in `node-wot-opcua-tools`, and `opcua-wot-binding` — found all of them on `nosec`, and
none carrying credentials.

## Deliberate extensions

Labelled as such in the README, so they are not mistaken for spec:

- policies outside the §6.3.3 list (`Basic128`, `Basic192`, `Basic192Rsa15`, `Basic256Rsa15`)
- the full policy URI as an alternative to the short name
- `combo` with `oneOf`, where the first alternative wins — the spec only uses `allOf`

## Testing

Full suite green at each of the three commits taken in isolation (77 / 82 / 97).

`test/opcua-security-e2e-test.ts` is new: a narrated tour against a real OPC UA server, which
connects and then asks the server which session it granted, so the assertions are about what
reached the wire rather than what the TD requested — the distinction the original bug hid behind.
`packages/examples/src/bindings/opcua/demo-opcua-secure.ts` is a runnable version.

## Follow-ups, not in this PR

- The same fail-open pattern is not opcua-specific; unsupported security schemes arguably ought to
  report a problem in every binding. Raised on #1401, better settled in core than here.
- `uav:issueToken` / `IssuedToken` needs upstream work: node-opcua's client-facing
  `UserIdentityInfo` union has no issued-token variant, so there is nothing for a binding to call
  into. Refused explicitly until then.
